### PR TITLE
allow nullable FK to 'calendar' from Event model

### DIFF
--- a/schedule/models/events.py
+++ b/schedule/models/events.py
@@ -35,7 +35,7 @@ class Event(models.Model):
     created_on = models.DateTimeField(_("created on"), default = timezone.now)
     rule = models.ForeignKey(Rule, null = True, blank = True, verbose_name=_("rule"), help_text=_("Select '----' for a one time only event."))
     end_recurring_period = models.DateTimeField(_("end recurring period"), null = True, blank = True, help_text=_("This date is ignored for one time only events."))
-    calendar = models.ForeignKey(Calendar, blank=True)
+    calendar = models.ForeignKey(Calendar, null=True, blank=True)
     objects = EventManager()
 
     class Meta:


### PR DESCRIPTION
As is, the admin seems to indicate 'calendar' is optional (from the blank=True rule) but validation requires a selection.  This way, events can be saved to a default calendar.
