### PR TITLE
fix Event.__unicode__() method 

### DIFF
--- a/schedule/models/events.py
+++ b/schedule/models/events.py
@@ -44,8 +44,8 @@ class Event(models.Model):
         app_label = 'schedule'
 
     def __unicode__(self):
-        date_format = u'l, %s' % ugettext("DATE_FORMAT")
-        return ugettext('%(title)s: %(start)s-%(end)s') % {
+        date_format = u'%s' % ugettext("DATE_FORMAT")
+        return ugettext('%(title)s: %(start)s - %(end)s') % {
             'title': self.title,
             'start': date(self.start, date_format),
             'end': date(self.end, date_format),


### PR DESCRIPTION
Perhaps i misunderstand the original intent of that method, but rendering a date with 'l, DATEFORMAT' as the format creates a weird string like "My Event: Wednesday, WedPMCDTMay_May-0500RMayPMCDT-Wednesday, WedPMCDTMay_May-0500RMayPMCDT" so i changed it so it will render like "MyEvent: May 22, 2013 - May 22, 2013" instead.
