### PR TITLE
prevent TypeError when comparing naive and aware dates in get_occurrence()

### DIFF
--- a/schedule/models/events.py
+++ b/schedule/models/events.py
@@ -111,6 +111,8 @@ class Event(models.Model):
         return Occurrence(event=self,start=start,end=end, original_start=start, original_end=end)
 
     def get_occurrence(self, date):
+        if timezone.is_naive(date):
+            date = timezone.make_aware(date, timezone.utc)
         rule = self.get_rrule_object()
         if rule:
             next_occurrence = rule.after(date, inc=True)


### PR DESCRIPTION
The date param is potentially timezone-naive (as i ran into with Occurrence.get_absolute_url), so coercing as timezone-aware.  This is perhaps not the best way to have fixed this bug, so please review, but it is a fix nonetheless.
