### PR TITLE
removed setuptools from install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
                  'Operating System :: OS Independent',
                  'Programming Language :: Python',
                  'Topic :: Utilities'],
-    install_requires=['setuptools', 'vobject', 'python-dateutil'],
+    install_requires=['vobject', 'python-dateutil'],
     license='BSD',
     test_suite = "schedule.tests",
 )


### PR DESCRIPTION
It's ironic, right?  Unless there's something i'm misunderstanding.  In my case, running 'pip install --upgrade' on this package was causing an attempt to reinstall easy_install as well.  Removing the requirement prevents that.
