### PR TITLE
MANIFEST.in - added recursive inclusion rule for `static` directory.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 recursive-include docs *
+recursive-include schedule/static *
 recursive-include schedule/templates *
 recursive-include schedule/fixtures *.json
 recursive-include project_sample *


### PR DESCRIPTION
Reference https://github.com/llazzaro/django-scheduler/issues/32
