### PR TITLE
Updated urlpatterns feed syntax to work with Django>1.1

### DIFF
--- a/schedule/urls.py
+++ b/schedule/urls.py
@@ -96,7 +96,7 @@ url(r'^occurrence/edit/(?P<event_id>\d+)/(?P<year>\d+)/(?P<month>\d+)/(?P<day>\d
 #feed urls
 url(r'^feed/calendar/(.*)/$',
     'django.contrib.syndication.views.Feed',
-    { "feed_dict": { "upcoming": UpcomingEventsFeed } }),
+    { "feed_dict": { "upcoming": UpcomingEventsFeed(None, None) } }),
 
 (r'^ical/calendar/(.*)/$', CalendarICalendar()),
 


### PR DESCRIPTION
Reference: https://github.com/llazzaro/django-scheduler/issues/34

The original code worked because in Django 1.1 it was used a feed class to connect a URL to this feed, now it's required an instance.
