### PR TITLE
escape the '&' used to join the query string. Now passes html validation.

### DIFF
--- a/schedule/templates/schedule/_month_table.html
+++ b/schedule/templates/schedule/_month_table.html
@@ -9,7 +9,7 @@
 {% for week in month.get_weeks %}
     <tr>
     <td>
-        <a href="{% url "week_calendar" calendar.slug %}{% querystring_for_date week.start %}">
+        <a href="{% url "week_calendar" calendar.slug %}{% querystring_for_date week.start True %}">
             {{week.start|date:"W"}}
         </a>
     </td>

--- a/schedule/templates/schedule/calendar_day.html
+++ b/schedule/templates/schedule/calendar_day.html
@@ -5,13 +5,13 @@
 
 {% include "schedule/_dialogs.html" %}
 <div class="navigation">
-  <a href="{% url "week_calendar" calendar.slug %}{% querystring_for_date periods.day.start 3 %}">
+  <a href="{% url "week_calendar" calendar.slug %}{% querystring_for_date periods.day.start 3 True %}">
     {% trans "Week" %}
   </a>
-  <a href="{% url "month_calendar" calendar.slug %}{% querystring_for_date periods.day.start 2 %}">
+  <a href="{% url "month_calendar" calendar.slug %}{% querystring_for_date periods.day.start 2 True %}">
     {% trans "Month" %}
   </a>
-  <a href="{% url "year_calendar" calendar.slug %}{% querystring_for_date periods.day.start 1%}">
+  <a href="{% url "year_calendar" calendar.slug %}{% querystring_for_date periods.day.start 1 True %}">
     {% trans "Year" %}
   </a>
 </div>

--- a/schedule/templates/schedule/calendar_month.html
+++ b/schedule/templates/schedule/calendar_month.html
@@ -14,10 +14,10 @@
   {% month_table calendar periods.month "regular" %}
 </div>
 <div class="navigation">
-  <a href="{% url "tri_month_calendar" calendar.slug %}{% querystring_for_date periods.month.start 2 %}">
+  <a href="{% url "tri_month_calendar" calendar.slug %}{% querystring_for_date periods.month.start 2 True %}">
     {% trans "Three Month Calendar" %}
   </a>
-  <a href="{% url "year_calendar" calendar.slug %}{% querystring_for_date periods.month.start 1%}">
+  <a href="{% url "year_calendar" calendar.slug %}{% querystring_for_date periods.month.start 1 True %}">
     {% trans "Full Year Calendar" %}
   </a>
 </div>

--- a/schedule/templates/schedule/calendar_tri_month.html
+++ b/schedule/templates/schedule/calendar_tri_month.html
@@ -20,10 +20,10 @@
 </table>
 </div>
 <div class="navigation">
-  <a href="{% url "month_calendar" calendar.slug %}{% querystring_for_date periods.month.start 2 %}">
+  <a href="{% url "month_calendar" calendar.slug %}{% querystring_for_date periods.month.start 2 True %}">
     {% trans "Monthly Calendar" %}
   </a>
-  <a href="{% url "year_calendar" calendar.slug %}{% querystring_for_date periods.month.start 1 %}">
+  <a href="{% url "year_calendar" calendar.slug %}{% querystring_for_date periods.month.start 1 True %}">
     {% trans "Full Year Calendar" %}
   </a>
 </div>

--- a/schedule/templates/schedule/calendar_week.html
+++ b/schedule/templates/schedule/calendar_week.html
@@ -6,10 +6,10 @@
 {% include "schedule/_dialogs.html" %}
 
 <div class="navigation">
-  <a href="{% url "month_calendar" calendar.slug %}{% querystring_for_date periods.week.start 2 %}">
+  <a href="{% url "month_calendar" calendar.slug %}{% querystring_for_date periods.week.start 2 True %}">
     {% trans "Month" %}
   </a>
-  <a href="{% url "year_calendar" calendar.slug %}{% querystring_for_date periods.week.start 1%}">
+  <a href="{% url "year_calendar" calendar.slug %}{% querystring_for_date periods.week.start 1 True %}">
     {% trans "Year" %}
   </a>
 </div>
@@ -28,7 +28,7 @@
   {% for day in periods.week.get_days %}
     <div class="weekday weekday{{forloop.counter}}">
       <div class="weekdayheader">
-        <a href="{% url "day_calendar" calendar.slug %}{% querystring_for_date day.start %}">
+        <a href="{% url "day_calendar" calendar.slug %}{% querystring_for_date day.start True %}">
           {{day.start|date:"l, d"}}
         </a>
       </div>

--- a/schedule/templates/schedule/calendar_year.html
+++ b/schedule/templates/schedule/calendar_year.html
@@ -8,7 +8,7 @@
     <tr>
     {% for month in periods.year.get_months %}
         <td valign="top">
-        <a href="{% url "month_calendar" calendar.slug %}{% querystring_for_date month.start 2 %}">
+        <a href="{% url "month_calendar" calendar.slug %}{% querystring_for_date month.start 2 True %}">
             {{month.name}}
         </a>
         {% month_table calendar month "small" %}</td>

--- a/schedule/templates/schedule/event.html
+++ b/schedule/templates/schedule/event.html
@@ -3,13 +3,13 @@
 
 {% block body %}
 <div class="navigation">
-  <a href="{% url "day_calendar" event.calendar.slug %}{% querystring_for_date event.start 3 %}">
+  <a href="{% url "day_calendar" event.calendar.slug %}{% querystring_for_date event.start 3 True %}">
     {% trans "Day" %}
   </a>
-  <a href="{% url "month_calendar" event.calendar.slug %}{% querystring_for_date event.start 2 %}">
+  <a href="{% url "month_calendar" event.calendar.slug %}{% querystring_for_date event.start 2 True %}">
     {% trans "Month" %}
   </a>
-  <a href="{% url "year_calendar" event.calendar.slug %}{% querystring_for_date event.start 1%}">
+  <a href="{% url "year_calendar" event.calendar.slug %}{% querystring_for_date event.start 1 True %}">
     {% trans "Year" %}
   </a>
 </div>

--- a/schedule/templates/schedule/occurrence.html
+++ b/schedule/templates/schedule/occurrence.html
@@ -3,10 +3,10 @@
 
 {% block body %}
 <div class="navigation">
-  <a href="{% url "day_calendar" occurrence.event.calendar.slug %}{% querystring_for_date occurrence.start 3 %}">
+  <a href="{% url "day_calendar" occurrence.event.calendar.slug %}{% querystring_for_date occurrence.start 3 True %}">
     {% trans "Day" %}
   </a>
-  <a href="{% url "month_calendar" occurrence.event.calendar.slug %}{% querystring_for_date occurrence.start 2 %}">
+  <a href="{% url "month_calendar" occurrence.event.calendar.slug %}{% querystring_for_date occurrence.start 2 True %}">
     {% trans "Month" %}
   </a>
 </div>

--- a/schedule/templatetags/scheduletags.py
+++ b/schedule/templatetags/scheduletags.py
@@ -3,6 +3,8 @@ from django.conf import settings
 from django import template
 from django.core.urlresolvers import reverse
 from django.utils.dateformat import format
+from django.utils.html import conditional_escape
+from django.utils.safestring import mark_safe
 from schedule.conf.settings import CHECK_EVENT_PERM_FUNC, CHECK_CALENDAR_PERM_FUNC
 from schedule.models import Calendar
 from schedule.periods import weekday_names, weekday_abbrs
@@ -181,12 +183,17 @@ register.tag('get_or_create_calendar', do_get_or_create_calendar_for_object)
 
 
 @register.simple_tag
-def querystring_for_date(date, num=6):
+@register.filter(needs_autoescape=True)
+def querystring_for_date(date, num=6, autoescape=None):
+    if autoescape:
+        esc = conditional_escape
+    else:
+        esc = lambda x: x
     query_string = '?'
     qs_parts = ['year=%d', 'month=%d', 'day=%d', 'hour=%d', 'minute=%d', 'second=%d']
     qs_vars = (date.year, date.month, date.day, date.hour, date.minute, date.second)
-    query_string += '&amp;'.join(qs_parts[:num]) % qs_vars[:num]
-    return query_string
+    query_string += esc('&'.join(qs_parts[:num]) % qs_vars[:num])
+    return mark_safe(query_string)
 
 
 @register.simple_tag

--- a/schedule/tests/test_templatetags.py
+++ b/schedule/tests/test_templatetags.py
@@ -1,6 +1,7 @@
 import datetime
 
 from django.test import TestCase
+from django.utils.html import escape
 
 from schedule.templatetags.scheduletags import querystring_for_date
 
@@ -8,6 +9,6 @@ class TestTemplateTags(TestCase):
     
     def test_querystring_for_datetime(self):
         date = datetime.datetime(2008,1,1,0,0,0)
-        query_string=querystring_for_date(date)
-        self.assertEqual("?year=2008&amp;month=1&amp;day=1&amp;hour=0&amp;minute=0&amp;second=0",
+        query_string=querystring_for_date(date, autoescape=True)
+        self.assertEqual(escape("?year=2008&month=1&day=1&hour=0&minute=0&second=0"),
             query_string)


### PR DESCRIPTION
Used the output from the calendar views (small month, 1 month, 3 months, this year, weekly, daily)
Ampersands should be escaped in a link in HTML (or any HTML attribute value).
Tested validation on:
http://validator.w3.org/check
http://achecker.ca/checker/index.php
