### PR TITLE
Prefetch occurrences in default get_events()

### DIFF
--- a/schedule/conf/settings.py
+++ b/schedule/conf/settings.py
@@ -51,7 +51,7 @@ if not CHECK_CALENDAR_PERM_FUNC:
 GET_EVENTS_FUNC = get_config('GET_EVENTS_FUNC', None)
 if not GET_EVENTS_FUNC:
     def get_events(request, calendar):
-        return calendar.event_set.prefetch_related('occurrence_set')
+        return calendar.event_set.prefetch_related('occurrence_set','rule')
 
     GET_EVENTS_FUNC = get_events
 


### PR DESCRIPTION
Suggest adding prefetch_related() to avoid N+1 queries. On my code queries per request went from 3000 to 20. It seems most anything you do with an event involves also looking at all the occurrences of that event, so this might be a more sensible default.
