### PR TITLE
Template fixes: 

### DIFF
--- a/schedule/templates/schedule/_event_options.html
+++ b/schedule/templates/schedule/_event_options.html
@@ -2,8 +2,8 @@
 
 <span class="actions">
 {% if edit_event %}
-<span class="edit">
-{% if occurrence.event.rule %}
+  <span class="edit">
+  {% if occurrence.event.rule %}
     {% if occurrence.id %}
         <a href="#" onclick="openURL('{{ edit_occurrence }}?next={{ here }}', event);">
             <img border="0" src="{% static "schedule/img/pencil.png" %}" alt="{% trans "Edit Event" %}">
@@ -13,16 +13,17 @@
             <img border="0" src="{% static "schedule/img/pencil.png" %}" alt="{% trans "Edit Event" %}">
         </a>
     {% endif %}
-{% else %}
+  {% else %}
     <a href="#" onclick="openURL('{{ edit_event }}?next={{ here }}', event);">
         <img border="0" src="{% static "schedule/img/pencil.png" %}" alt="{% trans "Edit Event" %}">
     </a>
+  {% endif %}
+  </span>
 {% endif %}
-{% endif %}
-</span>
+
 {% if delete_event %}
 <span class="delete">
-{% if occurrence.event.rule %}
+  {% if occurrence.event.rule %}
     {% if occurrence.id %}
         <a href="#" onclick="openURL('{{cancel_occurrence}}?next={{here}}', event);">
             <img border="0" src="{% static "schedule/img/delete.png" %}" alt="{% trans "Delete Event" %}">
@@ -32,11 +33,11 @@
             <img border="0" src="{% static "schedule/img/delete.png" %}" alt="{% trans "Delete Event" %}">
         </a>
     {% endif %}
-{% else %}
-<a href="#" onclick="openURL('{{delete_event}}?next={{here}}', event);">
+  {% else %}
+    <a href="#" onclick="openURL('{{delete_event}}?next={{here}}', event);">
     <img border="0" src="{% static "schedule/img/delete.png" %}" alt="{% trans "Delete Event" %}">
-</a>
-{% endif %}
-{% endif %}
+    </a>
+  {% endif %}
 </span>
+{% endif %}
 </span>

--- a/schedule/templates/schedule/_month_table.html
+++ b/schedule/templates/schedule/_month_table.html
@@ -9,7 +9,7 @@
 {% for week in month.get_weeks %}
     <tr>
     <td>
-        <a href="{% url "week_calendar" calendar.slug %}{% querystring_for_date week.start True %}">
+        <a href="{% url "week_calendar" calendar.slug %}{% querystring_for_date week.start 3 True %}">
             {{week.start|date:"W"}}
         </a>
     </td>

--- a/schedule/templates/schedule/calendar_week.html
+++ b/schedule/templates/schedule/calendar_week.html
@@ -16,7 +16,7 @@
 
 <div class="tablewrapper">
     <div class="calendarname">{{ calendar.name }}</div>
-    {% prevnext "week_calendar" calendar.slug periods.week "\Week W, M Y" %}
+    {% prevnext "week_calendar" calendar.slug periods.week "\W\e\ek W, M Y" %}
     <div class="now">
       <a href="{% url "week_calendar" calendar.slug %}">
         {% trans "This week" %}
@@ -28,7 +28,7 @@
   {% for day in periods.week.get_days %}
     <div class="weekday weekday{{forloop.counter}}">
       <div class="weekdayheader">
-        <a href="{% url "day_calendar" calendar.slug %}{% querystring_for_date day.start True %}">
+        <a href="{% url "day_calendar" calendar.slug %}{% querystring_for_date day.start 3 True %}">
           {{day.start|date:"l, d"}}
         </a>
       </div>

--- a/schedule/templates/site_base.html
+++ b/schedule/templates/site_base.html
@@ -22,7 +22,7 @@
 
     <body>
     <h3 id="demo">This is a demo of a django-schedule calendar</h3>
-    <p style="clear:both"/>
+    <p style="clear:both">
 
         <div id="body">
             {% if messages %}


### PR DESCRIPTION
Correct location for closing </span> tag. 
Pass parameter to querystring_for_date.
Properly escape 'Week' in template, otherwise it will display as 'WUTCUTCk'. 
Remove invalid closing '/' on paragraph tag.
