### PR TITLE
Don't require South since Django 1.7 is out

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,6 @@ setup(
         'pytz>=2013.9',
         'six>=1.3.0',
         'vobject>=0.8.1c',
-        'South>=0.8.4',
         'django-annoying>=0.7.9',
         'coverage>=3.6',
     ],


### PR DESCRIPTION
South shouldn't be a requirement, as Django 1.7 (latest stable version) has migrations built-in.
