### PR TITLE
Fixed _get_occ_list to return occs for split calendars.

### DIFF
--- a/schedule/models/events.py
+++ b/schedule/models/events.py
@@ -134,7 +134,7 @@ class Event(models.Model):
             if self.end_recurring_period and self.end_recurring_period < end:
                 end = self.end_recurring_period
             rule = self.get_rrule_object()
-            o_starts = rule.between(start - difference, end - difference, inc=True)
+            o_starts = rule.between(start, end, inc=True) or rule.between(start - difference, end - difference, inc=True) or rule.between(    start - (difference/2), end - (difference/2), inc=True)
             for o_start in o_starts:
                 o_end = o_start + difference
                 occurrences.append(self._create_occurrence(o_start, o_end))


### PR DESCRIPTION
Leonardo, here is another serious bug that I fixed and want to merge to the main branch. 

The bug affects occurences of recurring events when those occurrences are split in a calendar (e.g. starting on Tuesday but finishing on Wednesday in Week View, or starting in the morning but finishing in the evening of a Day view that is split in two). 

In these case, the first part of the occurrence is not shown (i.e. the part on Tuesday is not shown in Week View, the part in the morning is not shown in the Day view). See screenshots attached.
![probleminweeklyview](https://cloud.githubusercontent.com/assets/4582524/4794502/18de9026-5df5-11e4-97ca-2c431244e151.png)
![detailsofoccurrence](https://cloud.githubusercontent.com/assets/4582524/4794510/21dbef16-5df5-11e4-88b0-65c379a88b2d.png)

The fix here is not perfect (the problem will still occur in a day view that is split into 4 parts, for example), but at least it will solve the problem for the default setup (7 columns in week view, 2 columns in day view). 

Thanks,
Tim
