### PR TITLE
Recurring occurrences not displayed correctly in week view

### DIFF
--- a/schedule/models/events.py
+++ b/schedule/models/events.py
@@ -135,6 +135,7 @@ class Event(models.Model):
                 end = self.end_recurring_period
             rule = self.get_rrule_object()
 	    o_starts = []
+	    o_starts.append(rule.between(start, end, inc=True))
 	    o_starts.append(rule.between(start - (difference/2), end - (difference/2), inc=True))
 	    o_starts.append(rule.between(start - difference, end - difference, inc=True))
 	    for occ in o_starts:


### PR DESCRIPTION
While testing changes in pull request 88 (https://github.com/llazzaro/django-scheduler/pull/86), I noticed some cases where occurrences of recurring events were still not displayed correctly in week view. An occurrence split over two days was only shown on one of those days.
The problem was that o_starts was being overwritten when multiple rule matches were found. Turning o_starts into a list allows it hold these multiple rule matches. 
