### PR TITLE
Use icalendar instead of vobject package for feed

### DIFF
--- a/schedule/feeds/__init__.py
+++ b/schedule/feeds/__init__.py
@@ -2,7 +2,7 @@ from schedule.models import Calendar
 from django.contrib.syndication.views import Feed, FeedDoesNotExist
 from django.core.exceptions import ObjectDoesNotExist
 from django.conf import settings
-from schedule.feeds.icalendar import ICalendarFeed
+from schedule.feeds.ical import ICalendarFeed
 from django.http import HttpResponse
 import datetime, itertools
 from django.utils import timezone

--- a/schedule/feeds/ical.py
+++ b/schedule/feeds/ical.py
@@ -1,4 +1,4 @@
-import vobject
+import icalendar
 
 from django.http import HttpResponse
 
@@ -19,18 +19,21 @@ class ICalendarFeed(object):
         self.args = args
         self.kwargs = kwargs
 
-        cal = vobject.iCalendar()
+        cal = icalendar.Calendar()
+        cal.add('prodid', '-// django-scheduler //')
+        cal.add('version', '2.0')
 
         for item in self.items():
-
-            event = cal.add('vevent')
+            event = icalendar.Event()
 
             for vkey, key in EVENT_ITEMS:
                 value = getattr(self, 'item_' + key)(item)
                 if value:
-                    event.add(vkey).value = value
+                    event.add(vkey, value)
 
-        response = HttpResponse(cal.serialize())
+            cal.add_component(event)
+
+        response = HttpResponse(cal.to_ical())
         response['Content-Type'] = 'text/calendar'
 
         return response

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
         'python-dateutil>=2.1',
         'pytz>=2013.9',
         'six>=1.3.0',
-        'vobject>=0.8.1c',
+        'icalendar>=3.8.4',
         'South>=0.8.4',
         'django-annoying>=0.7.9',
         'coverage>=3.6',


### PR DESCRIPTION
This change is needed to later support Python 3 #61 
