### PR TITLE
Sets default timezone to Django default

### DIFF
--- a/schedule/views.py
+++ b/schedule/views.py
@@ -88,8 +88,11 @@ def calendar_by_periods(request, calendar_slug, periods=None, template_name="sch
     else:
         date = timezone.now()
     event_list = GET_EVENTS_FUNC(request, calendar)
-    local_timezone = request.session.setdefault('django_timezone', 'UTC')
-    local_timezone = pytz.timezone(local_timezone)
+
+    if 'django_timezone' in request.session:
+        local_timezone = pytz.timezone(request.session['django_timezone'])
+    else:
+        local_timezone = timezone.get_default_timezone()
     period_objects = {} 
     for period in periods:
         if period.__name__.lower() == 'year':


### PR DESCRIPTION
* Instead of defaulting to UTC (and then setting it for the session),
  this will use the Django default timezone (as defined in the
  settings module) until a 'django_timezone' session key gets set.