### PR TITLE
calendar view permissions

### DIFF
--- a/schedule/conf/settings.py
+++ b/schedule/conf/settings.py
@@ -31,6 +31,8 @@ if not CHECK_CALENDAR_PERM_FUNC:
 
     CHECK_CALENDAR_PERM_FUNC = check_calendar_permission
 
+CALENDAR_VIEW_PERM = get_config('CALENDAR_VIEW_PERM', False)
+
 # Callable used to customize the event list given for a calendar and user
 # (e.g. all events on that calendar, those events plus another calendar's events,
 # or the events filtered based on user permissions)

--- a/schedule/utils.py
+++ b/schedule/utils.py
@@ -8,9 +8,9 @@ from django.conf import settings
 from django.utils import timezone
 from django.utils.module_loading import import_string
 from schedule.conf.settings import (
-    CHECK_EVENT_PERM_FUNC, 
-    CHECK_CALENDAR_PERM_FUNC,
-    CALENDAR_VIEW_PERM)
+        CHECK_EVENT_PERM_FUNC, 
+        CHECK_CALENDAR_PERM_FUNC,
+        CALENDAR_VIEW_PERM)
 
 
 class EventListManager(object):
@@ -133,10 +133,8 @@ def check_calendar_permissions(function):
             allowed = CHECK_CALENDAR_PERM_FUNC(calendar, user)
             if not allowed:
                 return HttpResponseRedirect(settings.LOGIN_URL)
-
             # all checks passed
-            return function(request, *args, **kwargs)
-        return False
+        return function(request, *args, **kwargs)
 
     return decorator
 

--- a/schedule/views.py
+++ b/schedule/views.py
@@ -20,9 +20,9 @@ from schedule.conf.settings import GET_EVENTS_FUNC, OCCURRENCE_CANCEL_REDIRECT
 from schedule.forms import EventForm, OccurrenceForm
 from schedule.models import Calendar, Occurrence, Event
 from schedule.periods import weekday_names
-from schedule.utils import check_event_permissions, coerce_date_dict
+from schedule.utils import check_event_permissions, check_calendar_permissions, coerce_date_dict
 
-
+@check_calendar_permissions
 def calendar(request, calendar_slug, template='schedule/calendar.html'):
     """
     This view returns a calendar.  This view should be used if you are
@@ -40,7 +40,7 @@ def calendar(request, calendar_slug, template='schedule/calendar.html'):
         "calendar": calendar,
     }, context_instance=RequestContext(request))
 
-
+@check_calendar_permissions
 def calendar_by_periods(request, calendar_slug, periods=None, template_name="schedule/calendar_by_period.html"):
     """
     This view is for getting a calendar, but also getting periods with that


### PR DESCRIPTION
Added a decorator @check_calendar_permissions to the calendar views.
This decorator checks the new variable CALENDAR_VIEW_PERM in settings
which is either True or False to decide if the
CHECK_CALENDAR_PERM_FUNCTION also effects the views of the calendars and
not just the event editing for the calendar.