### PR TITLE
Clean up ContentType and GFK use.

### DIFF
--- a/schedule/models/calendars.py
+++ b/schedule/models/calendars.py
@@ -18,8 +18,6 @@ from schedule.utils import EventListManager, get_model_bases
 from django.utils import timezone
 from django.utils.encoding import python_2_unicode_compatible
 
-from schedule.utils import object_content_type
-
 
 class CalendarManager(models.Manager):
     """
@@ -100,12 +98,12 @@ class CalendarManager(models.Manager):
         If distinction is set it will filter out any relation that doesnt have
         that distinction.
         """
-        ct = object_content_type(obj)
+        ct = ContentType.objects.get_for_model(obj)
         if distinction:
             dist_q = Q(calendarrelation__distinction=distinction)
         else:
             dist_q = Q()
-        return self.filter(dist_q, Q(calendarrelation__object_id=obj.id, calendarrelation__content_type=ct))
+        return self.filter(dist_q, calendarrelation__object_id=obj.id, calendarrelation__content_type=ct)
 
 
 @python_2_unicode_compatible
@@ -198,11 +196,7 @@ class CalendarRelationManager(models.Manager):
         Creates a relation between calendar and content_object.
         See CalendarRelation for help on distinction and inheritable
         """
-        ct = object_content_type(content_object)
-        object_id = content_object.id
         cr = CalendarRelation(
-            content_type=ct,
-            object_id=object_id,
             calendar=calendar,
             distinction=distinction,
             content_object=content_object

--- a/schedule/models/events.py
+++ b/schedule/models/events.py
@@ -73,7 +73,7 @@ class Event(with_metaclass(ModelBase, *get_model_bases())):
     @property
     def hours(self):
         return float(self.seconds) / 3600
-        
+
     def get_absolute_url(self):
         return reverse('event', args=[self.id])
 
@@ -302,7 +302,7 @@ class EventRelationManager(models.Manager):
             )
         else:
             inherit_q = Q()
-        event_q = Q(dist_q, Q(eventrelation__object_id=content_object.id), Q(eventrelation__content_type=ct))
+        event_q = Q(dist_q, eventrelation__object_id=content_object.id, eventrelation__content_type=ct)
         return Event.objects.filter(inherit_q | event_q)
 
     def create_relation(self, event, content_object, distinction=None):
@@ -310,11 +310,7 @@ class EventRelationManager(models.Manager):
         Creates a relation between event and content_object.
         See EventRelation for help on distinction.
         """
-        ct = ContentType.objects.get_for_model(type(content_object))
-        object_id = content_object.id
         er = EventRelation(
-            content_type=ct,
-            object_id=object_id,
             event=event,
             distinction=distinction,
             content_object=content_object

--- a/schedule/utils.py
+++ b/schedule/utils.py
@@ -3,7 +3,6 @@ from functools import wraps
 import pytz
 import heapq
 from annoying.functions import get_object_or_None
-from django.contrib.contenttypes.models import ContentType
 from django.http import HttpResponseRedirect
 from django.conf import settings
 from django.utils import timezone
@@ -174,10 +173,3 @@ def get_model_bases():
         return [Model]
     else:
         return [import_string(x) for x in baseStrings]
-
-
-def object_content_type(obj):
-    obj.pk  # try to wake up the object in case it is a SimpleLazyObject
-    obj_type = type(obj._wrapped) if hasattr(obj, '_wrapped') else type(obj)
-    ct = ContentType.objects.get_for_model(obj_type)
-    return ct


### PR DESCRIPTION
* Remove object_content_type() as it re-implements inbuilt
  ContentType.objects.get_for_model().
* Remove extra Q() instantiation. Instead include filters in same Q.
* Setting content_object, handles setting the object_id and
  content_type, remove redundancy.