### PR TITLE
Missing django-bower as a pip install

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Installation
 ```bash
 npm install -g bower
 pip install django-scheduler
+pip install django-bower
 ```
 
 edit your `settings.py`


### PR DESCRIPTION
Was trying to follow the install instructions it was missing this step.