### PR TITLE
Day period now behaves correctly with non-utc tzs

### DIFF
--- a/schedule/periods.py
+++ b/schedule/periods.py
@@ -363,6 +363,7 @@ class Day(Period):
 
     def _get_day_range(self, date):
 
+        # localize the date before we typecast to naive dates
         if self.tzinfo is not None and timezone.is_aware(date):
             date = date.astimezone(self.tzinfo)
 

--- a/schedule/periods.py
+++ b/schedule/periods.py
@@ -362,6 +362,10 @@ class Day(Period):
                                   parent_persisted_occurrences, occurrence_pool, tzinfo=tzinfo)
 
     def _get_day_range(self, date):
+
+        if self.tzinfo is not None and timezone.is_aware(date):
+            date = date.astimezone(self.tzinfo)
+
         if isinstance(date, datetime.datetime):
             date = date.date()
 

--- a/tests/test_periods.py
+++ b/tests/test_periods.py
@@ -224,6 +224,30 @@ class TestDay(TestCase):
         self.assertEqual( period.start, slot_start )
         self.assertEqual( period.end, slot_end )
 
+    def test_get_day_range(self):
+        # This test exercises the case where a Day object is initiatized with
+        # no date, which causes the Day constructor to call timezone.now(),
+        # which always uses UTC.  This can cause a problem if the desired TZ
+        # is not UTC, because the _get_day_range method typecases the
+        # tx-aware datetimes object to naive objects.
+
+        # To simulate this case, we will initiatize the Day object with a UTC
+        # datetime, but pass in a non-UTC tzinfo
+        NY = pytz.timezone('America/New_York')
+
+        test_day = Day(
+            events=Event.objects.all(),
+            date=datetime.datetime(2015, 11, 5, 2, 30, tzinfo=pytz.utc),
+            tzinfo=NY)
+
+        expected_start = datetime.datetime(2015, 11, 4, 5, 00, tzinfo=pytz.utc)
+        expected_end = datetime.datetime(2015, 11, 5, 5, 00, tzinfo=pytz.utc)
+
+        self.assertEqual( test_day.start, expected_start)
+        self.assertEqual( test_day.end, expected_end)
+
+
+
 
 class TestOccurrencePool(TestCase):
 

--- a/tests/test_periods.py
+++ b/tests/test_periods.py
@@ -228,16 +228,19 @@ class TestDay(TestCase):
         # This test exercises the case where a Day object is initiatized with
         # no date, which causes the Day constructor to call timezone.now(),
         # which always uses UTC.  This can cause a problem if the desired TZ
-        # is not UTC, because the _get_day_range method typecases the
-        # tx-aware datetimes object to naive objects.
+        # is not UTC, because the _get_day_range method typecasts the
+        # tz-aware datetime to a naive datetime.
 
-        # To simulate this case, we will initiatize the Day object with a UTC
-        # datetime, but pass in a non-UTC tzinfo
+        # To simulate this case, we will create a NY tz date, localize that
+        # date to UTC, then create a Day object with the UTC date and NY TZ
+
         NY = pytz.timezone('America/New_York')
+        user_wall_time = datetime.datetime(2015, 11, 4, 21, 30, tzinfo=NY)
+        timezone_now = user_wall_time.astimezone(pytz.utc)
 
         test_day = Day(
             events=Event.objects.all(),
-            date=datetime.datetime(2015, 11, 5, 2, 30, tzinfo=pytz.utc),
+            date=timezone_now,
             tzinfo=NY)
 
         expected_start = datetime.datetime(2015, 11, 4, 5, 00, tzinfo=pytz.utc)


### PR DESCRIPTION
Fixes issue where all day periods would reflect the UTC day, regardless
of the tzinfo param.  Day period now uses tzinfo and reflects the day
relative to the tz.

Example of the problem behavior: (user's tz = America/New_York [-5])
user "wall time" = 2015-11-04 21:18 -0500

timezone.now(): 2015-11-05 02:18:12.248806+00:00

naive_start: 2015-11-05 00:00:00
local start: 2015-11-05 00:00:00-05:00
naive_end: 2015-11-06 00:00:00
local end: 2015-11-06 00:00:00-05:00

start: 2015-11-05 05:00:00+00:00
end: 2015-11-06 05:00:00+00:00

So occurrences would be returned for 2015-11-05, not 2015-11-04 as expected

New behavior:

user "wall time": 2015-11-04 21:23 -05:00

timezone.now(): 2015-11-05 02:23:52.008267+00:00
localized date: 2015-11-04 21:23:52.008267-05:00
naive_start: 2015-11-04 00:00:00
 naive_end: 2015-11-05 00:00:00
local start: 2015-11-04 00:00:00-05:00
local end: 2015-11-05 00:00:00-05:00
start: 2015-11-04 05:00:00+00:00
end: 2015-11-05 05:00:00+00:00

Now occurrences are returned for 2015-11-04 (NY TZ), as expected