### PR TITLE
Remove import error

### DIFF
--- a/schedule/urls.py
+++ b/schedule/urls.py
@@ -1,9 +1,5 @@
-try:
-    from django.conf.urls import url
-except ImportError:
-    from django.conf.urls.defaults import url
-
 from django.conf import settings
+from django.conf.urls import url
 from django.views.generic.list import ListView
 from django.views.static import serve
 from schedule.models import Calendar


### PR DESCRIPTION
django.conf.urls.defaults was removed in 1.6 and Django Scheduler required Django >= 1.7. It is safe to remove this compatibility shim.