### PR TITLE
Fix get_next_url() to be compatible with Django 1.9.

### DIFF
--- a/schedule/views.py
+++ b/schedule/views.py
@@ -16,6 +16,7 @@ from django.views.generic.base import TemplateResponseMixin
 from django.views.generic.detail import DetailView
 from django.views.generic.edit import (
         UpdateView, CreateView, DeleteView, ModelFormMixin, ProcessFormView)
+from django.utils.http import is_safe_url
 
 from schedule.conf.settings import (GET_EVENTS_FUNC, OCCURRENCE_CANCEL_REDIRECT,
                                     EVENT_NAME_PLACEHOLDER)
@@ -266,22 +267,13 @@ def get_occurrence(event_id, occurrence_id=None, year=None, month=None, day=None
     return event, occurrence
 
 
-def check_next_url(next_url):
-    """
-    Checks to make sure the next url is not redirecting to another page.
-    Basically it is a minimal security check.
-    """
-    if not next_url or '://' in next_url:
-        return None
-    return next_url
-
-
 def get_next_url(request, default):
     next_url = default
     if OCCURRENCE_CANCEL_REDIRECT:
         next_url = OCCURRENCE_CANCEL_REDIRECT
-    if 'next' in request.REQUEST and check_next_url(request.REQUEST['next']) is not None:
-        next_url = request.REQUEST['next']
+    _next_url = request.GET.get('next') if request.method in ['GET', 'HEAD'] else request.POST.get('next')
+    if _next_url and is_safe_url(url=_next_url, host=request.get_host()):
+        next_url = _next_url
     return next_url
 
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -9,7 +9,7 @@ from schedule.models.calendars import Calendar
 from schedule.models.events import Event
 from schedule.models.rules import Rule
 
-from schedule.views import check_next_url, coerce_date_dict
+from schedule.views import coerce_date_dict
 
 
 class TestViews(TestCase):
@@ -38,12 +38,6 @@ class TestViews(TestCase):
 
 
 class TestViewUtils(TestCase):
-    def test_check_next_url(self):
-        url = "http://thauber.com"
-        self.assertTrue(check_next_url(url) is None)
-        url = "/hello/world/"
-        self.assertEqual(url, check_next_url(url))
-
     def test_coerce_date_dict(self):
         self.assertEqual(
             coerce_date_dict({'year': '2008', 'month': '4', 'day': '2', 'hour': '4', 'minute': '4', 'second': '4'}),


### PR DESCRIPTION
Django 1.9 dropped request.REQUEST in favor of the more explicit
request.GET and request.POST. Use these instead.

In get_next_url(), removed check_next_url() which partially
re-implemnted Django's is_safe_url().