### PR TITLE
Improve use of six as a compatibility layer

### DIFF
--- a/schedule/feeds/__init__.py
+++ b/schedule/feeds/__init__.py
@@ -1,4 +1,4 @@
-from six.moves.builtins import str
+from django.utils.six.moves.builtins import str
 from schedule.models import Calendar
 from django.contrib.syndication.views import Feed, FeedDoesNotExist
 from django.core.exceptions import ObjectDoesNotExist

--- a/schedule/feeds/atom.py
+++ b/schedule/feeds/atom.py
@@ -1,5 +1,4 @@
 from django.utils.six.moves.builtins import str
-from django.utils.six.moves.builtins import object
 #
 # django-atompub by James Tauber <http://jtauber.com/>
 # http://code.google.com/p/django-atompub/

--- a/schedule/feeds/atom.py
+++ b/schedule/feeds/atom.py
@@ -1,5 +1,5 @@
-from six.moves.builtins import str
-from six.moves.builtins import object
+from django.utils.six.moves.builtins import str
+from django.utils.six.moves.builtins import object
 #
 # django-atompub by James Tauber <http://jtauber.com/>
 # http://code.google.com/p/django-atompub/

--- a/schedule/feeds/ical.py
+++ b/schedule/feeds/ical.py
@@ -1,5 +1,5 @@
-from six.moves.builtins import str
-from six.moves.builtins import object
+from django.utils.six.moves.builtins import str
+from django.utils.six.moves.builtins import object
 import icalendar
 
 from django.http import HttpResponse

--- a/schedule/feeds/ical.py
+++ b/schedule/feeds/ical.py
@@ -1,5 +1,4 @@
 from django.utils.six.moves.builtins import str
-from django.utils.six.moves.builtins import object
 import icalendar
 
 from django.http import HttpResponse

--- a/schedule/forms.py
+++ b/schedule/forms.py
@@ -1,4 +1,3 @@
-from django.utils.six.moves.builtins import object
 from django import forms
 from django.utils.translation import ugettext_lazy as _
 from schedule.models import Event, Occurrence

--- a/schedule/forms.py
+++ b/schedule/forms.py
@@ -1,4 +1,4 @@
-from six.moves.builtins import object
+from django.utils.six.moves.builtins import object
 from django import forms
 from django.utils.translation import ugettext_lazy as _
 from schedule.models import Event, Occurrence

--- a/schedule/models/calendars.py
+++ b/schedule/models/calendars.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
-from six.moves.builtins import str
-from six.moves.builtins import object
-from six import with_metaclass
+from django.utils.six.moves.builtins import str
+from django.utils.six.moves.builtins import object
+from django.utils.six import with_metaclass
 # -*- coding: utf-8 -*-
 
 import pytz

--- a/schedule/models/calendars.py
+++ b/schedule/models/calendars.py
@@ -1,6 +1,5 @@
 from __future__ import unicode_literals
 from django.utils.six.moves.builtins import str
-from django.utils.six.moves.builtins import object
 from django.utils.six import with_metaclass
 # -*- coding: utf-8 -*-
 

--- a/schedule/models/events.py
+++ b/schedule/models/events.py
@@ -1,5 +1,4 @@
 from __future__ import division, unicode_literals
-from django.utils.six.moves.builtins import object
 from django.utils.six import with_metaclass
 # -*- coding: utf-8 -*-
 from django.conf import settings as django_settings

--- a/schedule/models/events.py
+++ b/schedule/models/events.py
@@ -1,6 +1,6 @@
 from __future__ import division, unicode_literals
-from six.moves.builtins import object
-from six import with_metaclass
+from django.utils.six.moves.builtins import object
+from django.utils.six import with_metaclass
 # -*- coding: utf-8 -*-
 from django.conf import settings as django_settings
 import pytz

--- a/schedule/models/rules.py
+++ b/schedule/models/rules.py
@@ -1,6 +1,5 @@
 from __future__ import unicode_literals
 from django.utils.six.moves.builtins import str
-from django.utils.six.moves.builtins import object
 from django.utils.six import with_metaclass
 from dateutil.rrule import DAILY, MONTHLY, WEEKLY, YEARLY, HOURLY, MINUTELY, SECONDLY
 

--- a/schedule/models/rules.py
+++ b/schedule/models/rules.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
-from six.moves.builtins import str
-from six.moves.builtins import object
-from six import with_metaclass
+from django.utils.six.moves.builtins import str
+from django.utils.six.moves.builtins import object
+from django.utils.six import with_metaclass
 from dateutil.rrule import DAILY, MONTHLY, WEEKLY, YEARLY, HOURLY, MINUTELY, SECONDLY
 
 from django.db import models

--- a/schedule/periods.py
+++ b/schedule/periods.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
-from six.moves.builtins import range
-from six.moves.builtins import object
+from django.utils.six.moves.builtins import range
+from django.utils.six.moves.builtins import object
 import pytz
 import datetime
 import calendar as standardlib_calendar

--- a/schedule/periods.py
+++ b/schedule/periods.py
@@ -1,6 +1,5 @@
 from __future__ import unicode_literals
 from django.utils.six.moves.builtins import range
-from django.utils.six.moves.builtins import object
 import pytz
 import datetime
 import calendar as standardlib_calendar

--- a/schedule/templatetags/scheduletags.py
+++ b/schedule/templatetags/scheduletags.py
@@ -1,5 +1,5 @@
 from __future__ import division
-from six.moves.builtins import range
+from django.utils.six.moves.builtins import range
 import datetime
 from django.conf import settings
 from django import template

--- a/schedule/utils.py
+++ b/schedule/utils.py
@@ -1,4 +1,3 @@
-from django.utils.six.moves.builtins import object
 from functools import wraps
 import pytz
 import heapq

--- a/schedule/utils.py
+++ b/schedule/utils.py
@@ -1,4 +1,4 @@
-from six.moves.builtins import object
+from django.utils.six.moves.builtins import object
 from functools import wraps
 import pytz
 import heapq

--- a/schedule/views.py
+++ b/schedule/views.py
@@ -1,10 +1,8 @@
-from future import standard_library
-standard_library.install_aliases()
 import json
 import pytz
 import datetime
 import dateutil.parser
-from urllib.parse import quote
+from six.moves.urllib.parse import quote
 
 from django.db.models import Q
 from django.core.urlresolvers import reverse

--- a/schedule/views.py
+++ b/schedule/views.py
@@ -2,7 +2,7 @@ import json
 import pytz
 import datetime
 import dateutil.parser
-from six.moves.urllib.parse import quote
+from django.utils.six.moves.urllib.parse import quote
 
 from django.db.models import Q
 from django.core.urlresolvers import reverse

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,6 @@ setup(
         'six>=1.3.0',
         'icalendar>=3.8.4',
         'django-annoying>=0.8.0',
-        'future>=0.14.2',
     ],
     license='BSD',
     test_suite='runtests.runtests',

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,6 @@ setup(
         'Django>=1.7',
         'python-dateutil>=2.1',
         'pytz>=2013.9',
-        'six>=1.3.0',
         'icalendar>=3.8.4',
         'django-annoying>=0.8.0',
     ],

--- a/tests/test_periods.py
+++ b/tests/test_periods.py
@@ -1,5 +1,5 @@
-from six.moves.builtins import zip
-from six.moves.builtins import range
+from django.utils.six.moves.builtins import zip
+from django.utils.six.moves.builtins import range
 import datetime
 import pytz
 


### PR DESCRIPTION
Removed dependency on future.

The future package solves the same problem as six. That is, a compatibility layer for code to run on Python 2 and 3. As six is already a dependency, use that instead. Avoids using two libraries to solve a single issue.

Use Django's bundled six, avoids additional external dependency.

Django bundles and supports a version of six. As django-scheduler already depends on Django, might as well used the bundled version. Allows removing the dependency on external six library.

Removed import "from six.moves.builtins import object"; doesn't do anything useful.