### PR TITLE
Removed static URLs from urls.py.

### DIFF
--- a/schedule/urls.py
+++ b/schedule/urls.py
@@ -1,7 +1,5 @@
-from django.conf import settings
 from django.conf.urls import url
 from django.views.generic.list import ListView
-from django.views.static import serve
 from schedule.models import Calendar
 from schedule.feeds import UpcomingEventsFeed
 from schedule.feeds import CalendarICalendar
@@ -109,11 +107,3 @@ urlpatterns = [
 
     url(r'^$', ListView.as_view(queryset=Calendar.objects.all()), name='schedule'),
 ]
-
-if settings.DEBUG:
-    urlpatterns += [
-        url(
-            r'^static/(?P<path>.*)$',
-            serve,
-            {'document_root': settings.STATIC_ROOT, 'show_indexes': True}),
-    ]


### PR DESCRIPTION
Static files urls should be handled by the project using
django-scheduler, not by django-scheduler itself. The project may be
serving static files from a different location.

See https://docs.djangoproject.com/en/dev/intro/reusable-apps/

> During development, if you use django.contrib.staticfiles, this will
> be done automatically by runserver when DEBUG is set to True (see
> django.contrib.staticfiles.views.serve()).

> This method is grossly inefficient and probably insecure, so it is
> unsuitable for production.

> See Deploying static files for proper strategies to serve static
> files in production environments.