### PR TITLE
Removed references to files and directories that don't exist.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,4 +2,4 @@
 source = schedule
 
 [report]
-omit = tests/*,*/migrations/*,*/south_migrations/*,schedule/models/__init__.py,schedule/management/*,schedule/admin.py,schedule/manage.py,schedule/settings.py
+omit = tests/*,*/migrations/*,schedule/models/__init__.py,schedule/management/*,schedule/admin.py

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,5 +2,3 @@ recursive-include docs *
 recursive-include schedule/static *
 recursive-include schedule/templates *
 recursive-include schedule/locale *
-recursive-include schedule/fixtures *.json
-recursive-include project_sample *


### PR DESCRIPTION
These files and directories were likely removed in previous commits.

The following references were removed:

```
*/south_migrations/*  (Now use Django migrations)
schedule/manage.py    (No longer exists)
schedule/settings.py  (Moved to tests directory)
schedule/fixtures     (Moved to tests directory)
project_sample        (No longer exists)
```