### PR TITLE
Updated use of setuptools for creating distributions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 *.swp
 *~
 *.pyc
+/.coverage
+/.eggs/
+/dist/
+/django_scheduler.egg-info/
 /docs/_build/
-django_scheduler.egg-info
-.coverage

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,5 @@
+include LICENSE.txt
+include README.md
 recursive-include docs *
 recursive-include schedule/static *
 recursive-include schedule/templates *


### PR DESCRIPTION
Include LICENSE.txt and README.md in MANIFEST.in. These files can be
important when installing from a distributed tarball.

Added "dist" to .gitignore, created with the command "./setup.py sdist".

Added ".eggs" to .gitignore, created with the command "./setup.py test".