### PR TITLE
Unmatched tags in schedule/_month_table.html

### DIFF
--- a/schedule/templates/schedule/_month_table.html
+++ b/schedule/templates/schedule/_month_table.html
@@ -21,5 +21,5 @@
       {% endfor %}
       </tr>
   {% endfor %}
-</body>
+</tbody>
 </table>


### PR DESCRIPTION
```</body>``` on line 24 of ```scheduler/_month_table.html``` should actually have been ```</tbody>```.

I used django-scheduler in [this project](http://porygon.se/) and noticed that the HTML was invalid. Turns out the error was because of the extra ```</body>```.