### PR TITLE
Improve querystring_for_date template tag.

### DIFF
--- a/schedule/templates/schedule/_day_cell.html
+++ b/schedule/templates/schedule/_day_cell.html
@@ -7,7 +7,7 @@
   {% else %}
     <td>
   {% endif %}
-  <a href="{% url "day_calendar" calendar.slug %}{% querystring_for_date day.start 3 True %}">
+  <a href="{% url "day_calendar" calendar.slug %}{% querystring_for_date day.start 3 %}">
     <strong>{{day.start.day}}</strong>
   </a>
   {% ifnotequal size "small" %}

--- a/schedule/templates/schedule/_month_table.html
+++ b/schedule/templates/schedule/_month_table.html
@@ -12,7 +12,7 @@
   {% for week in month.get_weeks %}
       <tr>
       <td>
-          <a href="{% url "week_calendar" calendar.slug %}{% querystring_for_date week.start 3 True %}">
+          <a href="{% url "week_calendar" calendar.slug %}{% querystring_for_date week.start 3 %}">
               {{week.start|date:"W"}}
           </a>
       </td>

--- a/schedule/templates/schedule/calendar_day.html
+++ b/schedule/templates/schedule/calendar_day.html
@@ -5,13 +5,13 @@
 
 {% include "schedule/_dialogs.html" %}
 <div class="row row-centered">
-  <a class="btn btn-primary gradient" href="{% url "week_calendar" calendar.slug %}{% querystring_for_date periods.day.start 3 True %}">
+  <a class="btn btn-primary gradient" href="{% url "week_calendar" calendar.slug %}{% querystring_for_date periods.day.start 3 %}">
     {% trans "Week" %}
   </a>
-  <a class="btn btn-primary gradient" href="{% url "month_calendar" calendar.slug %}{% querystring_for_date periods.day.start 2 True %}">
+  <a class="btn btn-primary gradient" href="{% url "month_calendar" calendar.slug %}{% querystring_for_date periods.day.start 2 %}">
     {% trans "Month" %}
   </a>
-  <a class="btn btn-primary gradient" href="{% url "year_calendar" calendar.slug %}{% querystring_for_date periods.day.start 1 True %}">
+  <a class="btn btn-primary gradient" href="{% url "year_calendar" calendar.slug %}{% querystring_for_date periods.day.start 1 %}">
     {% trans "Year" %}
   </a>
 </div>

--- a/schedule/templates/schedule/calendar_month.html
+++ b/schedule/templates/schedule/calendar_month.html
@@ -16,10 +16,10 @@
   </div>
 </div>
 <div class="row row-centered">
-  <a href="{% url "tri_month_calendar" calendar.slug %}{% querystring_for_date periods.month.start 2 True %}">
+  <a href="{% url "tri_month_calendar" calendar.slug %}{% querystring_for_date periods.month.start 2 %}">
     {% trans "Three Month Calendar" %}
   </a>
-  <a href="{% url "year_calendar" calendar.slug %}{% querystring_for_date periods.month.start 1 True %}">
+  <a href="{% url "year_calendar" calendar.slug %}{% querystring_for_date periods.month.start 1 %}">
     {% trans "Full Year Calendar" %}
   </a>
 </div>

--- a/schedule/templates/schedule/calendar_tri_month.html
+++ b/schedule/templates/schedule/calendar_tri_month.html
@@ -20,10 +20,10 @@
 </table>
 </div>
 <div class="navigation">
-  <a href="{% url "month_calendar" calendar.slug %}{% querystring_for_date periods.month.start 2 True %}">
+  <a href="{% url "month_calendar" calendar.slug %}{% querystring_for_date periods.month.start 2 %}">
     {% trans "Monthly Calendar" %}
   </a>
-  <a href="{% url "year_calendar" calendar.slug %}{% querystring_for_date periods.month.start 1 True %}">
+  <a href="{% url "year_calendar" calendar.slug %}{% querystring_for_date periods.month.start 1 %}">
     {% trans "Full Year Calendar" %}
   </a>
 </div>

--- a/schedule/templates/schedule/calendar_week.html
+++ b/schedule/templates/schedule/calendar_week.html
@@ -6,10 +6,10 @@
 {% include "schedule/_dialogs.html" %}
 
 <div class="row row-centered">
-  <a href="{% url "month_calendar" calendar.slug %}{% querystring_for_date periods.week.start 2 True %}">
+  <a href="{% url "month_calendar" calendar.slug %}{% querystring_for_date periods.week.start 2 %}">
     {% trans "Month" %}
   </a>
-  <a href="{% url "year_calendar" calendar.slug %}{% querystring_for_date periods.week.start 1 True %}">
+  <a href="{% url "year_calendar" calendar.slug %}{% querystring_for_date periods.week.start 1 %}">
     {% trans "Year" %}
   </a>
 </div>
@@ -28,7 +28,7 @@
   {% for day in periods.week.get_days %}
     <div class="col-md-3">
       <div class="row row-centered">
-        <a href="{% url "day_calendar" calendar.slug %}{% querystring_for_date day.start 3 True %}">
+        <a href="{% url "day_calendar" calendar.slug %}{% querystring_for_date day.start 3 %}">
           {{day.start|date:"l, d"}}
         </a>
       </div>

--- a/schedule/templates/schedule/calendar_year.html
+++ b/schedule/templates/schedule/calendar_year.html
@@ -8,7 +8,7 @@
       {% for month in periods.year.get_months %}
         <div class="col-md-3">
           <div class="row row-centered">
-            <button class="btn btn-custom active" href="{% url "month_calendar" calendar.slug %}{% querystring_for_date month.start 2 True %}">{{month.name}}</button>
+            <button class="btn btn-custom active" href="{% url "month_calendar" calendar.slug %}{% querystring_for_date month.start 2 %}">{{month.name}}</button>
           </div>
           <div>
             {% month_table calendar month "small" %}

--- a/schedule/templates/schedule/event.html
+++ b/schedule/templates/schedule/event.html
@@ -3,13 +3,13 @@
 
 {% block body %}
 <div class="navigation">
-  <a class="btn btn-primary gradient" href="{% url "day_calendar" event.calendar.slug %}{% querystring_for_date event.start 3 True %}">
+  <a class="btn btn-primary gradient" href="{% url "day_calendar" event.calendar.slug %}{% querystring_for_date event.start 3 %}">
     {% trans "Day" %}
   </a>
-  <a class="btn btn-primary gradient" href="{% url "month_calendar" event.calendar.slug %}{% querystring_for_date event.start 2 True %}">
+  <a class="btn btn-primary gradient" href="{% url "month_calendar" event.calendar.slug %}{% querystring_for_date event.start 2 %}">
     {% trans "Month" %}
   </a>
-  <a class="btn btn-primary gradient" href="{% url "year_calendar" event.calendar.slug %}{% querystring_for_date event.start 1 True %}">
+  <a class="btn btn-primary gradient" href="{% url "year_calendar" event.calendar.slug %}{% querystring_for_date event.start 1 %}">
     {% trans "Year" %}
   </a>
 </div>

--- a/schedule/templates/schedule/occurrence.html
+++ b/schedule/templates/schedule/occurrence.html
@@ -3,10 +3,10 @@
 
 {% block body %}
 <div class="navigation">
-  <a href="{% url "day_calendar" occurrence.event.calendar.slug %}{% querystring_for_date occurrence.start 3 True %}">
+  <a href="{% url "day_calendar" occurrence.event.calendar.slug %}{% querystring_for_date occurrence.start 3 %}">
     {% trans "Day" %}
   </a>
-  <a href="{% url "month_calendar" occurrence.event.calendar.slug %}{% querystring_for_date occurrence.start 2 True %}">
+  <a href="{% url "month_calendar" occurrence.event.calendar.slug %}{% querystring_for_date occurrence.start 2 %}">
     {% trans "Month" %}
   </a>
 </div>

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -39,7 +39,7 @@ class TestTemplateTags(TestCase):
 
     def test_querystring_for_datetime(self):
         date = datetime.datetime(datetime.datetime.now().year, 1, 1, 0, 0, 0)
-        query_string = querystring_for_date(date, autoescape=True)
+        query_string = querystring_for_date(date)
         self.assertEqual(escape('?year={0}&month=1&day=1&hour=0&minute=0&second=0'.format(datetime.datetime.now().year)),
             query_string)
 


### PR DESCRIPTION
* Don't register as both a template tag or a filter, it is just one.
* As simple_tag now always escapes output, don't take parameter
  autoescape.
* For compatibility with older Django versions, always escape the
  output.