### PR TITLE
A period object should always be returned. Calling code uses period o…

### DIFF
--- a/schedule/periods.py
+++ b/schedule/periods.py
@@ -135,7 +135,7 @@ class Period(object):
     def get_time_slot(self, start, end):
         if start >= self.start and end <= self.end:
             return Period(self.events, start, end)
-        return None
+        return Period([], start, end)
 
     def create_sub_period(self, cls, start=None, tzinfo=None):
         if tzinfo is None:

--- a/tests/test_periods.py
+++ b/tests/test_periods.py
@@ -223,6 +223,14 @@ class TestDay(TestCase):
         self.assertEqual( period.start, slot_start )
         self.assertEqual( period.end, slot_end )
 
+    def test_time_slot_with_dst(self):
+        tzinfo = pytz.timezone('America/Vancouver')
+        slot_start = datetime.datetime(2016, 3, 13, 0, 0, tzinfo=tzinfo)
+        slot_end = datetime.datetime(2016, 3, 14, 0, 0, tzinfo=tzinfo)
+        period = self.day.get_time_slot(slot_start, slot_end)
+        self.assertEqual(period.start, slot_start)
+        self.assertEqual(period.end, slot_end)
+
     def test_get_day_range(self):
         # This test exercises the case where a Day object is initiatized with
         # no date, which causes the Day constructor to call timezone.now(),


### PR DESCRIPTION
…bject even when no events occur within time period.

If you look in scheduletags, you'll see that it assumes get_time_slot always returns a valid Period object, and uses the result within _cook_slots() to update the display, even if there are no events.