### PR TITLE
Simplify interface to CalendarByPeriodsView to accept a single period.

### DIFF
--- a/schedule/templates/schedule/calendar_compact_month.html
+++ b/schedule/templates/schedule/calendar_compact_month.html
@@ -2,5 +2,5 @@
 {% load scheduletags %}
 {% block body %}
 <h1>{{ calendar.name }}</h1>
-{% month_table calendar periods.month "small" %}
+{% month_table calendar period "small" %}
 {% endblock %}

--- a/schedule/templates/schedule/calendar_day.html
+++ b/schedule/templates/schedule/calendar_day.html
@@ -5,19 +5,19 @@
 
 {% include "schedule/_dialogs.html" %}
 <div class="row row-centered">
-  <a class="btn btn-primary gradient" href="{% url "week_calendar" calendar.slug %}{% querystring_for_date periods.day.start 3 %}">
+  <a class="btn btn-primary gradient" href="{% url "week_calendar" calendar.slug %}{% querystring_for_date period.start 3 %}">
     {% trans "Week" %}
   </a>
-  <a class="btn btn-primary gradient" href="{% url "month_calendar" calendar.slug %}{% querystring_for_date periods.day.start 2 %}">
+  <a class="btn btn-primary gradient" href="{% url "month_calendar" calendar.slug %}{% querystring_for_date period.start 2 %}">
     {% trans "Month" %}
   </a>
-  <a class="btn btn-primary gradient" href="{% url "year_calendar" calendar.slug %}{% querystring_for_date periods.day.start 1 %}">
+  <a class="btn btn-primary gradient" href="{% url "year_calendar" calendar.slug %}{% querystring_for_date period.start 1 %}">
     {% trans "Year" %}
   </a>
 </div>
 <div class="row row-centered">
     <h1>{{ calendar.name }}</h1>
-    {% prevnext "day_calendar" calendar periods.day "l, F d, Y" %}
+    {% prevnext "day_calendar" calendar period "l, F d, Y" %}
     <div class="now">
       <a class="btn btn-primary gradient" href="{% url "day_calendar" calendar.slug %}">
         {% trans "Today" %}
@@ -26,11 +26,11 @@
 </div>
   <div class="row row-centered">
     <div>
-      {% daily_table periods.day %}
+      {% daily_table period %}
     </div>
 
     <div>
-      {% daily_table periods.day %}
+      {% daily_table period %}
     </div>
 </div>
 

--- a/schedule/templates/schedule/calendar_month.html
+++ b/schedule/templates/schedule/calendar_month.html
@@ -5,21 +5,21 @@
 {% include "schedule/_dialogs.html" %}
 <div class="row row-centered">
   <div class="calendarname">{{ calendar.name }}</div>
-  {% prevnext "month_calendar" calendar periods.month "F Y"%}
+  {% prevnext "month_calendar" calendar period "F Y"%}
   <div class="now row-centered">
     <a href="{% url "month_calendar" calendar.slug %}">
       {% trans "This month" %}
     </a>
   </div>
   <div class="center span7">
-    {% month_table calendar periods.month "regular" %}
+    {% month_table calendar period "regular" %}
   </div>
 </div>
 <div class="row row-centered">
-  <a href="{% url "tri_month_calendar" calendar.slug %}{% querystring_for_date periods.month.start 2 %}">
+  <a href="{% url "tri_month_calendar" calendar.slug %}{% querystring_for_date period.start 2 %}">
     {% trans "Three Month Calendar" %}
   </a>
-  <a href="{% url "year_calendar" calendar.slug %}{% querystring_for_date periods.month.start 1 %}">
+  <a href="{% url "year_calendar" calendar.slug %}{% querystring_for_date period.start 1 %}">
     {% trans "Full Year Calendar" %}
   </a>
 </div>

--- a/schedule/templates/schedule/calendar_tri_month.html
+++ b/schedule/templates/schedule/calendar_tri_month.html
@@ -3,7 +3,7 @@
 {% block body %}
 <div class="tablewrapper">
   <div class="calendarname">{{ calendar.name }}</div>
-  {% prevnext "tri_month_calendar" calendar periods.month "F Y"%}
+  {% prevnext "tri_month_calendar" calendar period "F Y"%}
   <div class="now">
     <a href="{% url "tri_month_calendar" calendar.slug %}">
       {% trans "This month" %}
@@ -11,19 +11,19 @@
   </div>
 <table align="center">
 	<tr>
-		<td valign="top">{% month_table calendar periods.month "small" -1 %}</td>
+		<td valign="top">{% month_table calendar period "small" -1 %}</td>
 		<td width="12">&nbsp;</td>
-		<td valign="top">{% month_table calendar periods.month "small" %}</td>
+		<td valign="top">{% month_table calendar period "small" %}</td>
 		<td width="12">&nbsp;</td>
-		<td valign="top">{% month_table calendar periods.month "small" +1 %}</td>
+		<td valign="top">{% month_table calendar period "small" +1 %}</td>
 	</tr>
 </table>
 </div>
 <div class="navigation">
-  <a href="{% url "month_calendar" calendar.slug %}{% querystring_for_date periods.month.start 2 %}">
+  <a href="{% url "month_calendar" calendar.slug %}{% querystring_for_date period.start 2 %}">
     {% trans "Monthly Calendar" %}
   </a>
-  <a href="{% url "year_calendar" calendar.slug %}{% querystring_for_date periods.month.start 1 %}">
+  <a href="{% url "year_calendar" calendar.slug %}{% querystring_for_date period.start 1 %}">
     {% trans "Full Year Calendar" %}
   </a>
 </div>

--- a/schedule/templates/schedule/calendar_week.html
+++ b/schedule/templates/schedule/calendar_week.html
@@ -6,17 +6,17 @@
 {% include "schedule/_dialogs.html" %}
 
 <div class="row row-centered">
-  <a href="{% url "month_calendar" calendar.slug %}{% querystring_for_date periods.week.start 2 %}">
+  <a href="{% url "month_calendar" calendar.slug %}{% querystring_for_date period.start 2 %}">
     {% trans "Month" %}
   </a>
-  <a href="{% url "year_calendar" calendar.slug %}{% querystring_for_date periods.week.start 1 %}">
+  <a href="{% url "year_calendar" calendar.slug %}{% querystring_for_date period.start 1 %}">
     {% trans "Year" %}
   </a>
 </div>
 
 <div class="row row-centered">
     <div>{{ calendar.name }}</div>
-    {% prevnext "week_calendar" calendar periods.week "\W\e\ek W, M Y" %}
+    {% prevnext "week_calendar" calendar period "\W\e\ek W, M Y" %}
     <div class="now">
       <a href="{% url "week_calendar" calendar.slug %}">
         {% trans "This week" %}
@@ -25,7 +25,7 @@
 </div>
 
 <div class="row row-centered">
-  {% for day in periods.week.get_days %}
+  {% for day in period.get_days %}
     <div class="col-md-3">
       <div class="row row-centered">
         <a href="{% url "day_calendar" calendar.slug %}{% querystring_for_date day.start 3 %}">

--- a/schedule/templates/schedule/calendar_year.html
+++ b/schedule/templates/schedule/calendar_year.html
@@ -3,9 +3,9 @@
 {% block body %}
 <div class="tablewrapper">
     <div class="calendarname">{{ calendar.name }}</div>
-    {% prevnext "year_calendar" calendar periods.year "Y" %}
+    {% prevnext "year_calendar" calendar period "Y" %}
     <div class="content">
-      {% for month in periods.year.get_months %}
+      {% for month in period.get_months %}
         <div class="col-md-3">
           <div class="row row-centered">
             <button class="btn btn-custom active" href="{% url "month_calendar" calendar.slug %}{% querystring_for_date month.start 2 %}">{{month.name}}</button>

--- a/schedule/urls.py
+++ b/schedule/urls.py
@@ -21,32 +21,32 @@ urlpatterns = [
     url(r'^calendar/year/(?P<calendar_slug>[-\w]+)/$',
         CalendarByPeriodsView.as_view(),
         name="year_calendar",
-        kwargs={'periods': [Year], 'template_name': 'schedule/calendar_year.html'}),
+        kwargs={'period': Year, 'template_name': 'schedule/calendar_year.html'}),
 
     url(r'^calendar/tri_month/(?P<calendar_slug>[-\w]+)/$',
         CalendarByPeriodsView.as_view(),
         name="tri_month_calendar",
-        kwargs={'periods': [Month], 'template_name': 'schedule/calendar_tri_month.html'}),
+        kwargs={'period': Month, 'template_name': 'schedule/calendar_tri_month.html'}),
 
     url(r'^calendar/compact_month/(?P<calendar_slug>[-\w]+)/$',
         CalendarByPeriodsView.as_view(),
         name="compact_calendar",
-        kwargs={'periods': [Month], 'template_name': 'schedule/calendar_compact_month.html'}),
+        kwargs={'period': Month, 'template_name': 'schedule/calendar_compact_month.html'}),
 
     url(r'^calendar/month/(?P<calendar_slug>[-\w]+)/$',
         CalendarByPeriodsView.as_view(),
         name="month_calendar",
-        kwargs={'periods': [Month], 'template_name': 'schedule/calendar_month.html'}),
+        kwargs={'period': Month, 'template_name': 'schedule/calendar_month.html'}),
 
     url(r'^calendar/week/(?P<calendar_slug>[-\w]+)/$',
         CalendarByPeriodsView.as_view(),
         name="week_calendar",
-        kwargs={'periods': [Week], 'template_name': 'schedule/calendar_week.html'}),
+        kwargs={'period': Week, 'template_name': 'schedule/calendar_week.html'}),
 
     url(r'^calendar/daily/(?P<calendar_slug>[-\w]+)/$',
         CalendarByPeriodsView.as_view(),
         name="day_calendar",
-        kwargs={'periods': [Day], 'template_name': 'schedule/calendar_day.html'}),
+        kwargs={'period': Day, 'template_name': 'schedule/calendar_day.html'}),
 
     url(r'^calendar/(?P<calendar_slug>[-\w]+)/$',
         CalendarView.as_view(),

--- a/schedule/views.py
+++ b/schedule/views.py
@@ -101,7 +101,7 @@ class CalendarByPeriodsView(CalendarMixin, DetailView):
     def get_context_data(self, request, **kwargs):
         context = super(CalendarByPeriodsView, self).get_context_data(**kwargs)
         calendar = self.object
-        periods = kwargs.get('periods', None)
+        period_class = kwargs['period']
         try:
             date = coerce_date_dict(request.GET)
         except ValueError:
@@ -116,13 +116,11 @@ class CalendarByPeriodsView(CalendarMixin, DetailView):
         event_list = GET_EVENTS_FUNC(request, calendar)
 
         local_timezone = timezone.get_current_timezone()
-        period_objects = {}
-        for period in periods:
-            period_objects[period.__name__.lower()] = period(event_list, date, tzinfo=local_timezone)
+        period = period_class(event_list, date, tzinfo=local_timezone)
 
         context.update({
             'date': date,
-            'periods': period_objects,
+            'period': period,
             'calendar': calendar,
             'weekday_names': weekday_names,
             'here': quote(request.get_full_path()),

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -82,7 +82,7 @@ class TestUrls(TestCase):
         self.assertEqual(self.response.status_code, 200)
         self.assertEqual(self.response.context[0]["calendar"].name,
                          "Example Calendar")
-        month = self.response.context[0]["periods"]['month']
+        month = self.response.context[0]["period"]
         self.assertEqual((month.start, month.end),
                          (datetime.datetime(2000, 11, 1, 0, 0, tzinfo=pytz.utc),
                           datetime.datetime(2000, 12, 1, 0, 0, tzinfo=pytz.utc)))


### PR DESCRIPTION
All uses of CalendarByPeriodsView a single period is passed. However,
the interface requires a list of periods. As this is always used as a
scalar, might as well pass it as a scalar. This also simplifies
templates as they can now use the period object as a scalar instead of
indexing a dictionary.