### PR TITLE
#206 bugfix object_id in CalendarRelation

### DIFF
--- a/schedule/migrations/0001_initial.py
+++ b/schedule/migrations/0001_initial.py
@@ -30,7 +30,7 @@ class Migration(migrations.Migration):
             name='CalendarRelation',
             fields=[
                 ('id', models.AutoField(primary_key=True, serialize=False, verbose_name='ID', auto_created=True)),
-                ('object_id', models.IntegerField()),
+                ('object_id', models.CharField()),
                 ('distinction', models.CharField(null=True, max_length=20, verbose_name='distinction')),
                 ('inheritable', models.BooleanField(default=True, verbose_name='inheritable')),
                 ('calendar', models.ForeignKey(to='schedule.Calendar', verbose_name='calendar')),

--- a/schedule/migrations/0001_initial.py
+++ b/schedule/migrations/0001_initial.py
@@ -30,7 +30,7 @@ class Migration(migrations.Migration):
             name='CalendarRelation',
             fields=[
                 ('id', models.AutoField(primary_key=True, serialize=False, verbose_name='ID', auto_created=True)),
-                ('object_id', models.CharField()),
+                ('object_id', models.CharField(max_length=32)),
                 ('distinction', models.CharField(null=True, max_length=20, verbose_name='distinction')),
                 ('inheritable', models.BooleanField(default=True, verbose_name='inheritable')),
                 ('calendar', models.ForeignKey(to='schedule.Calendar', verbose_name='calendar')),

--- a/schedule/models/calendars.py
+++ b/schedule/models/calendars.py
@@ -228,7 +228,7 @@ class CalendarRelation(with_metaclass(ModelBase, *get_model_bases())):
 
     calendar = models.ForeignKey(Calendar, verbose_name=_("calendar"))
     content_type = models.ForeignKey(ContentType)
-    object_id = models.IntegerField()
+    object_id = models.CharField(max_length=32)
     content_object = fields.GenericForeignKey('content_type', 'object_id')
     distinction = models.CharField(_("distinction"), max_length=20, null=True)
     inheritable = models.BooleanField(_("inheritable"), default=True)

--- a/schedule/models/events.py
+++ b/schedule/models/events.py
@@ -483,7 +483,7 @@ class EventRelation(with_metaclass(ModelBase, *get_model_bases())):
     '''
     event = models.ForeignKey(Event, verbose_name=_("event"))
     content_type = models.ForeignKey(ContentType)
-    object_id = models.IntegerField()
+    object_id = models.CharField(max_length=32)
     content_object = fields.GenericForeignKey('content_type', 'object_id')
     distinction = models.CharField(_("distinction"), max_length=20, null=True)
 


### PR DESCRIPTION
Format of object_id in CalendarRelation changed to accept UUID pk, based on [documentation](https://docs.djangoproject.com/en/1.9/ref/contrib/contenttypes/#django.contrib.contenttypes.fields.GenericForeignKey)
