### PR TITLE
API requests without calendar slug returns all calendars

### DIFF
--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -145,3 +145,36 @@ class TestUrls(TestCase):
         self.response = self.client.get(reverse("delete_event", kwargs={"event_id": 1}), {})
         self.assertEqual(self.response.status_code, 404)
         self.client.logout()
+
+# TODO: finish this
+    def test_occurences_api_works_with_and_without_cal_slug(self):
+        # create a calendar and event
+        self.calendar = Calendar.objects.create(name="MyCal", slug='MyCalSlug')
+        self.rule = Rule.objects.create(frequency="DAILY")
+        data = {
+            'title': 'Recent Event',
+            'start': datetime.datetime(2008, 1, 5, 8, 0, tzinfo=pytz.utc),
+            'end': datetime.datetime(2008, 1, 5, 9, 0, tzinfo=pytz.utc),
+            'end_recurring_period': datetime.datetime(2008, 5, 5, 0, 0, tzinfo=pytz.utc),
+            'rule': self.rule,
+            'calendar': self.calendar
+        }
+        self.event = Event.objects.create(**data)
+        # test calendar slug
+        self.response = self.client.get(reverse('api_occurences'), 
+                                         {'start': '2008-01-05',
+                                         'end': '2008-02-05'}
+                                        )
+        self.assertEqual(self.response.status_code, 200)
+        # TODO: test event is in response
+        # test no calendar slug
+        self.response = self.client.get(reverse("api_occurences"),
+                                        {'start': '2008-01-05',
+                                         'end': '2008-02-05'}
+                                        )
+        self.assertEqual(self.response.status_code, 200)
+        # TODO: test event is in response
+
+# TODO: 
+#    def test_cal_slug_filters_returned_events
+

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,5 +1,6 @@
-import pytz
 import datetime
+import json
+import pytz
 
 from django.test.utils import override_settings
 from django.test import TestCase
@@ -146,35 +147,74 @@ class TestUrls(TestCase):
         self.assertEqual(self.response.status_code, 404)
         self.client.logout()
 
-# TODO: finish this
     def test_occurences_api_works_with_and_without_cal_slug(self):
         # create a calendar and event
-        self.calendar = Calendar.objects.create(name="MyCal", slug='MyCalSlug')
-        self.rule = Rule.objects.create(frequency="DAILY")
+        calendar = Calendar.objects.create(name="MyCal", slug='MyCalSlug')
+        rule = Rule.objects.create()
         data = {
             'title': 'Recent Event',
             'start': datetime.datetime(2008, 1, 5, 8, 0, tzinfo=pytz.utc),
             'end': datetime.datetime(2008, 1, 5, 9, 0, tzinfo=pytz.utc),
             'end_recurring_period': datetime.datetime(2008, 5, 5, 0, 0, tzinfo=pytz.utc),
-            'rule': self.rule,
-            'calendar': self.calendar
+            'calendar': calendar
         }
-        self.event = Event.objects.create(**data)
+        event = Event.objects.create(**data)
         # test calendar slug
-        self.response = self.client.get(reverse('api_occurences'), 
+        response = self.client.get(reverse('api_occurences'), 
                                          {'start': '2008-01-05',
-                                         'end': '2008-02-05'}
+                                         'end': '2008-02-05',
+                                         'calendar_slug':event.calendar.slug}
                                         )
-        self.assertEqual(self.response.status_code, 200)
-        # TODO: test event is in response
-        # test no calendar slug
-        self.response = self.client.get(reverse("api_occurences"),
-                                        {'start': '2008-01-05',
-                                         'end': '2008-02-05'}
-                                        )
-        self.assertEqual(self.response.status_code, 200)
-        # TODO: test event is in response
+        self.assertEqual(response.status_code, 200)
+        resp_list = json.loads(response.content.decode('utf-8'))
+        self.assertIn(event.title, [d['title'] for d in resp_list])
+        # test works with no calendar slug
+        response = self.client.get(reverse("api_occurences"),
+                                   {'start': '2008-01-05',
+                                    'end': '2008-02-05'
+                                    }
+                                  )
+        self.assertEqual(response.status_code, 200)
+        resp_list = json.loads(response.content.decode('utf-8'))
+        self.assertIn(event.title, [d['title'] for d in resp_list])
 
-# TODO: 
-#    def test_cal_slug_filters_returned_events
+    def test_cal_slug_filters_returned_events(self):
+        calendar1 = Calendar.objects.create(name="MyCal1", slug='MyCalSlug1')
+        calendar2 = Calendar.objects.create(name="MyCal2", slug='MyCalSlug2')
+        data1 = {
+            'title': 'Recent Event 1',
+            'start': datetime.datetime(2008, 1, 5, 8, 0, tzinfo=pytz.utc),
+            'end': datetime.datetime(2008, 1, 5, 9, 0, tzinfo=pytz.utc),
+            'end_recurring_period': datetime.datetime(2008, 5, 5, 0, 0, tzinfo=pytz.utc),
+            'calendar': calendar1
+        }
+        data2 = {
+            'title': 'Recent Event 2',
+            'start': datetime.datetime(2008, 1, 5, 8, 0, tzinfo=pytz.utc),
+            'end': datetime.datetime(2008, 1, 5, 9, 0, tzinfo=pytz.utc),
+            'end_recurring_period': datetime.datetime(2008, 5, 5, 0, 0, tzinfo=pytz.utc),
+            'calendar': calendar2
+        }
+        event1 = Event.objects.create(**data1)
+        event2 = Event.objects.create(**data2)
+        # Test both present with no cal arg
+        response = self.client.get(reverse("api_occurences"),
+                                   {'start': '2008-01-05',
+                                   'end': '2008-02-05'}
+                                   )
+        self.assertEqual(response.status_code, 200)
+        resp_list = json.loads(response.content.decode('utf-8'))
+        self.assertIn(event1.title, [d['title'] for d in resp_list])
+        self.assertIn(event2.title, [d['title'] for d in resp_list])
+        # test event2 not in event1 response
+        response = self.client.get(reverse("api_occurences"),
+                                    {'start': '2008-01-05',
+                                     'end': '2008-02-05',
+                                     'calendar_slug': event1.calendar.slug}
+                                   )
+        self.assertEqual(response.status_code, 200)
+        resp_list = json.loads(response.content.decode('utf-8'))
+        self.assertIn(event1.title, [d['title'] for d in resp_list])
+        self.assertNotIn(event2.title, [d['title'] for d in resp_list])
+        print([d['title'] for d in resp_list])
 


### PR DESCRIPTION
Adds the ability to ommit `calender_slug` param on `api/occurences/` endpoint to expose all calendar events. 

Currently assumes that only one calendar slug will be provided, though having multiple calendar_slug values would be useful for viewing 2 or 3 (but not all) calendars.