### PR TITLE
Separate API from retrieving occurrences. Use dependency injection.

### DIFF
--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -176,6 +176,13 @@ class TestUrls(TestCase):
         self.response = self.client.get(reverse("api_occurences"))
         self.assertEqual(self.response.status_code, 400)
 
+    def test_occurrences_api_without_calendar_slug_return_status_404(self):
+        self.response = self.client.get(reverse("api_occurences"),
+                                        {'start': datetime.datetime(2008, 1, 5),
+                                         'end': datetime.datetime(2008, 1, 6),
+                                         'calendar_slug': 'NoMatch'})
+        self.assertEqual(self.response.status_code, 400)
+
     def test_occurences_api_checks_valid_occurrence_ids(self):
         # create a calendar and event
         self.calendar = Calendar.objects.create(name="MyCal", slug='MyCalSlug')


### PR DESCRIPTION
This separation makes it easier to test the internal APIs, and mock any parameters.

It also makes it easy for anyone to write their own wrapper around functions like _api_occurrences, allowing them to add whatever data they need directly to the response_data. As an example, if an event were associated with something like...a form, and you want to display a link to the form in the fullcalendar event dialog, you can now easily add the data to the response_data in a wrapper function, without having to convert from JSON first.