### PR TITLE
Add missing on_delete to all ForeignKeys.

### DIFF
--- a/schedule/migrations/0001_initial.py
+++ b/schedule/migrations/0001_initial.py
@@ -33,8 +33,8 @@ class Migration(migrations.Migration):
                 ('object_id', models.IntegerField()),
                 ('distinction', models.CharField(null=True, max_length=20, verbose_name='distinction')),
                 ('inheritable', models.BooleanField(default=True, verbose_name='inheritable')),
-                ('calendar', models.ForeignKey(to='schedule.Calendar', verbose_name='calendar')),
-                ('content_type', models.ForeignKey(to='contenttypes.ContentType')),
+                ('calendar', models.ForeignKey(to='schedule.Calendar', verbose_name='calendar', on_delete=models.CASCADE)),
+                ('content_type', models.ForeignKey(to='contenttypes.ContentType', on_delete=models.CASCADE)),
             ],
             options={
                 'verbose_name_plural': 'calendar relations',
@@ -53,8 +53,8 @@ class Migration(migrations.Migration):
                 ('created_on', models.DateTimeField(auto_now_add=True, verbose_name='created on')),
                 ('updated_on', models.DateTimeField(auto_now=True, verbose_name='updated on')),
                 ('end_recurring_period', models.DateTimeField(blank=True, null=True, help_text='This date is ignored for one time only events.', verbose_name='end recurring period')),
-                ('calendar', models.ForeignKey(blank=True, null=True, to='schedule.Calendar', verbose_name='calendar')),
-                ('creator', models.ForeignKey(blank=True, null=True, related_name='creator', verbose_name='creator', to=settings.AUTH_USER_MODEL)),
+                ('calendar', models.ForeignKey(blank=True, null=True, to='schedule.Calendar', verbose_name='calendar', on_delete=models.CASCADE)),
+                ('creator', models.ForeignKey(blank=True, null=True, related_name='creator', verbose_name='creator', to=settings.AUTH_USER_MODEL, on_delete=models.CASCADE)),
             ],
             options={
                 'verbose_name_plural': 'events',
@@ -68,8 +68,8 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(primary_key=True, serialize=False, verbose_name='ID', auto_created=True)),
                 ('object_id', models.IntegerField()),
                 ('distinction', models.CharField(null=True, max_length=20, verbose_name='distinction')),
-                ('content_type', models.ForeignKey(to='contenttypes.ContentType')),
-                ('event', models.ForeignKey(to='schedule.Event', verbose_name='event')),
+                ('content_type', models.ForeignKey(to='contenttypes.ContentType', on_delete=models.CASCADE)),
+                ('event', models.ForeignKey(to='schedule.Event', verbose_name='event', on_delete=models.CASCADE)),
             ],
             options={
                 'verbose_name_plural': 'event relations',
@@ -90,7 +90,7 @@ class Migration(migrations.Migration):
                 ('original_end', models.DateTimeField(verbose_name='original end')),
                 ('created_on', models.DateTimeField(auto_now_add=True, verbose_name='created on')),
                 ('updated_on', models.DateTimeField(auto_now=True, verbose_name='updated on')),
-                ('event', models.ForeignKey(to='schedule.Event', verbose_name='event')),
+                ('event', models.ForeignKey(to='schedule.Event', verbose_name='event', on_delete=models.CASCADE)),
             ],
             options={
                 'verbose_name_plural': 'occurrences',
@@ -116,7 +116,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='event',
             name='rule',
-            field=models.ForeignKey(blank=True, null=True, to='schedule.Rule', verbose_name='rule', help_text="Select '----' for a one time only event."),
+            field=models.ForeignKey(blank=True, null=True, to='schedule.Rule', verbose_name='rule', help_text="Select '----' for a one time only event.", on_delete=models.CASCADE),
             preserve_default=True,
         ),
     ]

--- a/schedule/models/calendars.py
+++ b/schedule/models/calendars.py
@@ -227,8 +227,8 @@ class CalendarRelation(with_metaclass(ModelBase, *get_model_bases())):
     may not scale well.  If you use this, keep that in mind.
     '''
 
-    calendar = models.ForeignKey(Calendar, verbose_name=_("calendar"))
-    content_type = models.ForeignKey(ContentType)
+    calendar = models.ForeignKey(Calendar, on_delete=models.CASCADE, verbose_name=_("calendar"))
+    content_type = models.ForeignKey(ContentType, on_delete=models.CASCADE)
     object_id = models.IntegerField()
     content_object = fields.GenericForeignKey('content_type', 'object_id')
     distinction = models.CharField(_("distinction"), max_length=20, null=True)

--- a/schedule/models/events.py
+++ b/schedule/models/events.py
@@ -57,15 +57,30 @@ class Event(with_metaclass(ModelBase, *get_model_bases())):
     end = models.DateTimeField(_("end"), help_text=_("The end time must be later than the start time."))
     title = models.CharField(_("title"), max_length=255)
     description = models.TextField(_("description"), null=True, blank=True)
-    creator = models.ForeignKey(django_settings.AUTH_USER_MODEL, null=True, blank=True, verbose_name=_("creator"),
-                                related_name='creator')
+    creator = models.ForeignKey(
+        django_settings.AUTH_USER_MODEL,
+        on_delete=models.CASCADE,
+        null=True,
+        blank=True,
+        verbose_name=_("creator"),
+        related_name='creator')
     created_on = models.DateTimeField(_("created on"), auto_now_add=True)
     updated_on = models.DateTimeField(_("updated on"), auto_now=True)
-    rule = models.ForeignKey(Rule, null=True, blank=True, verbose_name=_("rule"),
-                             help_text=_("Select '----' for a one time only event."))
+    rule = models.ForeignKey(
+        Rule,
+        on_delete=models.CASCADE,
+        null=True,
+        blank=True,
+        verbose_name=_("rule"),
+        help_text=_("Select '----' for a one time only event."))
     end_recurring_period = models.DateTimeField(_("end recurring period"), null=True, blank=True,
                                                 help_text=_("This date is ignored for one time only events."))
-    calendar = models.ForeignKey(Calendar, null=True, blank=True, verbose_name=_("calendar"))
+    calendar = models.ForeignKey(
+        Calendar,
+        on_delete=models.CASCADE,
+        null=True,
+        blank=True,
+        verbose_name=_("calendar"))
     color_event = models.CharField(_("Color event"), null=True, blank=True, max_length=10)
     objects = EventManager()
 
@@ -480,8 +495,8 @@ class EventRelation(with_metaclass(ModelBase, *get_model_bases())):
     DISCLAIMER: while this model is a nice out of the box feature to have, it
     may not scale well.  If you use this keep that in mind.
     '''
-    event = models.ForeignKey(Event, verbose_name=_("event"))
-    content_type = models.ForeignKey(ContentType)
+    event = models.ForeignKey(Event, on_delete=models.CASCADE, verbose_name=_("event"))
+    content_type = models.ForeignKey(ContentType, on_delete=models.CASCADE)
     object_id = models.IntegerField()
     content_object = fields.GenericForeignKey('content_type', 'object_id')
     distinction = models.CharField(_("distinction"), max_length=20, null=True)
@@ -499,7 +514,7 @@ class EventRelation(with_metaclass(ModelBase, *get_model_bases())):
 
 @python_2_unicode_compatible
 class Occurrence(with_metaclass(ModelBase, *get_model_bases())):
-    event = models.ForeignKey(Event, verbose_name=_("event"))
+    event = models.ForeignKey(Event, on_delete=models.CASCADE, verbose_name=_("event"))
     title = models.CharField(_("title"), max_length=255, blank=True, null=True)
     description = models.TextField(_("description"), blank=True, null=True)
     start = models.DateTimeField(_("start"))


### PR DESCRIPTION
Fixes warnings like:

RemovedInDjango20Warning: on_delete will be a required arg for ForeignKey in Django 2.0. Set it to models.CASCADE on models and in existing migrations if you want to maintain the current default behavior.

See https://docs.djangoproject.com/en/dev/ref/models/fields/#django.db.models.ForeignKey.on_delete