### PR TITLE
Added db index for important date field

### DIFF
--- a/schedule/migrations/0003_auto_20160715_0028.py
+++ b/schedule/migrations/0003_auto_20160715_0028.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('schedule', '0002_event_color_event'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='event',
+            name='end',
+            field=models.DateTimeField(help_text='The end time must be later than the start time.', verbose_name='end', db_index=True),
+        ),
+        migrations.AlterField(
+            model_name='event',
+            name='end_recurring_period',
+            field=models.DateTimeField(help_text='This date is ignored for one time only events.', null=True, verbose_name='end recurring period', db_index=True, blank=True),
+        ),
+        migrations.AlterField(
+            model_name='event',
+            name='start',
+            field=models.DateTimeField(verbose_name='start', db_index=True),
+        ),
+        migrations.AlterField(
+            model_name='occurrence',
+            name='end',
+            field=models.DateTimeField(verbose_name='end', db_index=True),
+        ),
+        migrations.AlterField(
+            model_name='occurrence',
+            name='start',
+            field=models.DateTimeField(verbose_name='start', db_index=True),
+        ),
+        migrations.AlterIndexTogether(
+            name='event',
+            index_together=set([('start', 'end')]),
+        ),
+        migrations.AlterIndexTogether(
+            name='occurrence',
+            index_together=set([('start', 'end')]),
+        ),
+    ]

--- a/schedule/models/events.py
+++ b/schedule/models/events.py
@@ -53,8 +53,8 @@ class Event(with_metaclass(ModelBase, *get_model_bases())):
     This model stores meta data for a date.  You can relate this data to many
     other models.
     '''
-    start = models.DateTimeField(_("start"))
-    end = models.DateTimeField(_("end"), help_text=_("The end time must be later than the start time."))
+    start = models.DateTimeField(_("start"), db_index=True)
+    end = models.DateTimeField(_("end"), db_index=True, help_text=_("The end time must be later than the start time."))
     title = models.CharField(_("title"), max_length=255)
     description = models.TextField(_("description"), null=True, blank=True)
     creator = models.ForeignKey(
@@ -73,7 +73,7 @@ class Event(with_metaclass(ModelBase, *get_model_bases())):
         blank=True,
         verbose_name=_("rule"),
         help_text=_("Select '----' for a one time only event."))
-    end_recurring_period = models.DateTimeField(_("end recurring period"), null=True, blank=True,
+    end_recurring_period = models.DateTimeField(_("end recurring period"), null=True, blank=True, db_index=True,
                                                 help_text=_("This date is ignored for one time only events."))
     calendar = models.ForeignKey(
         Calendar,
@@ -88,6 +88,9 @@ class Event(with_metaclass(ModelBase, *get_model_bases())):
         verbose_name = _('event')
         verbose_name_plural = _('events')
         app_label = 'schedule'
+        index_together = (
+            ('start', 'end'),
+        )
 
     def __str__(self):
         return ugettext('%(title)s: %(start)s - %(end)s') % {
@@ -517,8 +520,8 @@ class Occurrence(with_metaclass(ModelBase, *get_model_bases())):
     event = models.ForeignKey(Event, on_delete=models.CASCADE, verbose_name=_("event"))
     title = models.CharField(_("title"), max_length=255, blank=True, null=True)
     description = models.TextField(_("description"), blank=True, null=True)
-    start = models.DateTimeField(_("start"))
-    end = models.DateTimeField(_("end"))
+    start = models.DateTimeField(_("start"), db_index=True)
+    end = models.DateTimeField(_("end"), db_index=True)
     cancelled = models.BooleanField(_("cancelled"), default=False)
     original_start = models.DateTimeField(_("original start"))
     original_end = models.DateTimeField(_("original end"))
@@ -529,6 +532,9 @@ class Occurrence(with_metaclass(ModelBase, *get_model_bases())):
         verbose_name = _("occurrence")
         verbose_name_plural = _("occurrences")
         app_label = 'schedule'
+        index_together = (
+            ('start', 'end'),
+        )
 
     def __init__(self, *args, **kwargs):
         super(Occurrence, self).__init__(*args, **kwargs)


### PR DESCRIPTION
As advised in many sources, I added some database index to important date fields:
- `Event`'s `start`, `end` and `end_recurring_period`
- `Occurrence`'s `start` and `end`

I added also multiple field index:
- `Event`'s `start`+`end`
- `Occurrence`'s `start`+`end`

Maybe we could add more but I do not yet have the knowledge of scheduler for make that.
