### PR TITLE
Fix deprecation warning of the form:

### DIFF
--- a/schedule/utils.py
+++ b/schedule/utils.py
@@ -44,10 +44,7 @@ class EventListManager(object):
             except StopIteration:
                 pass
 
-        while True:
-            if len(occurrences) == 0:
-                raise StopIteration
-
+        while occurrences:
             generator = occurrences[0][1]
 
             try:


### PR DESCRIPTION
PendingDeprecationWarning: generator 'EventListManager.occurrences_after' raised StopIteration

See:

https://docs.python.org/3/whatsnew/3.5.html#pep-479-change-stopiteration-handling-inside-generators