### PR TITLE
Update importing of NoArgsCommand to BaseCommand

### DIFF
--- a/schedule/management/commands/load_example_data.py
+++ b/schedule/management/commands/load_example_data.py
@@ -1,10 +1,13 @@
-from django.core.management.base import NoArgsCommand
+try:
+    from django.core.management.base import NoArgsCommand as BaseCommand
+except ImportError:
+    from django.core.management.base import BaseCommand
 
 
-class Command(NoArgsCommand):
+class Command(BaseCommand):
     help = "Load some sample data into the db"
 
-    def handle_noargs(self, **options):
+    def handle(self, **options):
         import datetime
         from schedule.models import Calendar
         from schedule.models import Event

--- a/schedule/management/commands/load_sample_data.py
+++ b/schedule/management/commands/load_sample_data.py
@@ -1,10 +1,13 @@
-from django.core.management.base import NoArgsCommand
+try:
+    from django.core.management.base import NoArgsCommand as BaseCommand
+except ImportError:
+    from django.core.management.base import BaseCommand
 
 
-class Command(NoArgsCommand):
+class Command(BaseCommand):
     help = "Load some sample data into the db"
 
-    def handle_noargs(self, **options):
+    def handle(self, **options):
         import datetime
         from schedule.models import Calendar
         from schedule.models import Event

--- a/tests/test_management_command.py
+++ b/tests/test_management_command.py
@@ -1,0 +1,13 @@
+from django.core.management import call_command
+from django.test import TestCase
+from django.utils.six import StringIO
+
+
+class TestManagementCommand(TestCase):
+    def test_command_output(self):
+        out = StringIO()
+        call_command('load_example_data', stdout=out)
+        self.assertIn('', out.getvalue())
+        call_command('load_sample_data', stdout=out)
+        self.assertIn('', out.getvalue())
+


### PR DESCRIPTION
After Django 1.10 NoArgsCommand is eliminated in favor of BaseCommand.
So the old structure won't be neccesary.