### PR TITLE
Fixes TypeError on rules with single parameter args

### DIFF
--- a/schedule/models/events.py
+++ b/schedule/models/events.py
@@ -1,4 +1,5 @@
 from __future__ import division, unicode_literals
+from django.utils import six
 from django.utils.six import with_metaclass
 # -*- coding: utf-8 -*-
 from django.conf import settings as django_settings
@@ -332,20 +333,17 @@ class Event(with_metaclass(ModelBase, *get_model_bases())):
         empty = False
 
         event_params = {}
-
-        for param in rule_params:
+        for param, values in six.iteritems(rule_params):
             # start date influences rule params
-            if (param in param_dict_order and param_dict_order[param] > freq_order and
-                    param in start_params):
-                sp = start_params[param]
-                if sp == rule_params[param] or sp in rule_params[param]:
-                    event_params[param] = [sp]
+            if param in param_dict_order and param_dict_order[param] > freq_order and param in start_params:
+                if start_params[param] in values:
+                    event_params[param] = [start_params[param]]
                 else:
                     event_params = {'count': 0}
                     empty = True
                     break
             else:
-                event_params[param] = rule_params[param]
+                event_params[param] = values[0] if len(values) == 1 else values
         return event_params, empty
 
     @property

--- a/schedule/models/events.py
+++ b/schedule/models/events.py
@@ -187,8 +187,8 @@ class Event(with_metaclass(ModelBase, *get_model_bases())):
             if not empty:
                 return rrule.rrule(frequency, dtstart=dtstart, **params)
             else:
-                year = self.start.year - 1
-                return rrule.rrule(frequency, dtstart=dtstart, until=self.start.replace(year=year))
+                year = dtstart.year - 1
+                return rrule.rrule(frequency, dtstart=dtstart, until=dtstart.replace(year=year))
 
     def _create_occurrence(self, start, end=None):
         if end is None:

--- a/schedule/models/rules.py
+++ b/schedule/models/rules.py
@@ -76,7 +76,7 @@ class Rule(with_metaclass(ModelBase, *get_model_bases())):
         """
         >>> rule = Rule(params = "count:1;bysecond:1;byminute:1,2,4,5")
         >>> rule.get_params()
-        {'count': 1, 'byminute': [1, 2, 4, 5], 'bysecond': 1}
+        {'count': [1], 'byminute': [1, 2, 4, 5], 'bysecond': [1]}
         """
         if self.params is None:
             return {}

--- a/schedule/models/rules.py
+++ b/schedule/models/rules.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+from collections import defaultdict
 from django.utils.six.moves.builtins import str
 from django.utils.six import with_metaclass
 from dateutil.rrule import DAILY, MONTHLY, WEEKLY, YEARLY, HOURLY, MINUTELY, SECONDLY
@@ -80,15 +81,13 @@ class Rule(with_metaclass(ModelBase, *get_model_bases())):
         if self.params is None:
             return {}
         params = self.params.split(';')
-        param_dict = []
+        param_dict = defaultdict(list)
         for param in params:
             param = param.split(':')
             if len(param) == 2:
-                param = (str(param[0]), [int(p) for p in param[1].split(',')])
-                if len(param[1]) == 1:
-                    param = (param[0], param[1][0])
-                param_dict.append(param)
-        return dict(param_dict)
+                param = dict([(str(param[0]), [int(p) for p in param[1].split(',')])])
+                param_dict.update(param)
+        return param_dict
 
     def __str__(self):
         """Human readable string for Rule"""

--- a/tests/test_rule.py
+++ b/tests/test_rule.py
@@ -9,5 +9,5 @@ class TestPeriod(TestCase):
 
     def test_get_params(self):
         rule = Rule(params = "count:1;bysecond:1;byminute:1,2,4,5")
-        expected =  {'count': 1, 'byminute': [1, 2, 4, 5], 'bysecond': 1}
-        self.assertEqual(rule.get_params(), expected)
+        expected = {'count': [1], 'byminute': [1, 2, 4, 5], 'bysecond': [1]}
+        self.assertDictEqual(rule.get_params(), expected)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -297,11 +297,18 @@ class TestUrls(TestCase):
         feed_url = reverse('upcoming_events_feed', kwargs={'calendar_id': 1})
         response = self.client.get(feed_url)
         self.assertEquals(response.status_code, 200)
-        expected_feed = '<?xml version="1.0" encoding="utf-8"?>\n<rss xmlns:atom="http://www.w3.org/2005/Atom" version="2.0"><channel><title></title><link>http://example.com/calendar/example/</link><description></description><atom:link rel="self" href="http://example.com/feed/calendar/upcoming/1/"></atom:link><language>en-us</language><lastBuildDate>'
-        self.assertTrue(six.b(expected_feed) in response.content)
+        expected_feed = '<?xml version="1.0" encoding="utf-8"?>\n<rss xmlns:atom="http://www.w3.org/2005/Atom" version="2.0"><channel><title></title><link>http://example.com/calendar/example/</link><description></description><atom:link href="http://example.com/feed/calendar/upcoming/1/" rel="self"></atom:link><language>en-us</language><lastBuildDate>'
+        try:
+            self.assertTrue(expected_feed in response.content)
+        except TypeError:
+            self.assertTrue(six.b(expected_feed) in response.content)
 
     def test_calendar_view_home(self):
         calendar_view_url = reverse('calendar_home', kwargs={'calendar_slug': 'example'})
         response = self.client.get(calendar_view_url)
         self.assertEquals(response.status_code, 200)
-        self.assertTrue(six.b('<a href="/feed/calendar/upcoming/1/">Feed</a>') in response.content)
+        expected = '<a href="/feed/calendar/upcoming/1/">Feed</a>'
+        try:
+            self.assertTrue(expected in response.content)
+        except TypeError:
+            self.assertTrue(six.b('<a href="/feed/calendar/upcoming/1/">Feed</a>') in response.content)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -2,9 +2,9 @@ import datetime
 import json
 import pytz
 
-from django.test import override_settings
+from django.test import TestCase, override_settings
 from django.core.urlresolvers import reverse
-from django.test import TestCase
+from django.utils import six
 
 from schedule.models.calendars import Calendar
 from schedule.models.events import Event, Occurrence
@@ -297,11 +297,11 @@ class TestUrls(TestCase):
         feed_url = reverse('upcoming_events_feed', kwargs={'calendar_id': 1})
         response = self.client.get(feed_url)
         self.assertEquals(response.status_code, 200)
-        expected_feed = '<?xml version="1.0" encoding="utf-8"?>\n<rss xmlns:atom="http://www.w3.org/2005/Atom" version="2.0"><channel><title></title><link>http://example.com/calendar/example/</link><description></description><atom:link href="http://example.com/feed/calendar/upcoming/1/" rel="self"></atom:link><language>en-us</language><lastBuildDate>'
+        expected_feed = six.b('<?xml version="1.0" encoding="utf-8"?>\n<rss xmlns:atom="http://www.w3.org/2005/Atom" version="2.0"><channel><title></title><link>http://example.com/calendar/example/</link><description></description><atom:link href="http://example.com/feed/calendar/upcoming/1/" rel="self"></atom:link><language>en-us</language><lastBuildDate>')
         self.assertTrue(expected_feed in response.content)
 
     def test_calendar_view_home(self):
         calendar_view_url = reverse('calendar_home', kwargs={'calendar_slug': 'example'})
         response = self.client.get(calendar_view_url)
         self.assertEquals(response.status_code, 200)
-        self.assertTrue('<a href="/feed/calendar/upcoming/1/">Feed</a>' in response.content)
+        self.assertTrue(six.b('<a href="/feed/calendar/upcoming/1/">Feed</a>') in response.content)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -297,8 +297,8 @@ class TestUrls(TestCase):
         feed_url = reverse('upcoming_events_feed', kwargs={'calendar_id': 1})
         response = self.client.get(feed_url)
         self.assertEquals(response.status_code, 200)
-        expected_feed = six.b('<?xml version="1.0" encoding="utf-8"?>\n<rss xmlns:atom="http://www.w3.org/2005/Atom" version="2.0"><channel><title></title><link>http://example.com/calendar/example/</link><description></description><atom:link href="http://example.com/feed/calendar/upcoming/1/" rel="self"></atom:link><language>en-us</language><lastBuildDate>')
-        self.assertTrue(expected_feed in response.content)
+        expected_feed = '<?xml version="1.0" encoding="utf-8"?>\n<rss xmlns:atom="http://www.w3.org/2005/Atom" version="2.0"><channel><title></title><link>http://example.com/calendar/example/</link><description></description><atom:link rel="self" href="http://example.com/feed/calendar/upcoming/1/"></atom:link><language>en-us</language><lastBuildDate>'
+        self.assertTrue(six.b(expected_feed) in response.content)
 
     def test_calendar_view_home(self):
         calendar_view_url = reverse('calendar_home', kwargs={'calendar_slug': 'example'})


### PR DESCRIPTION
Fixes #262 

This PR also contains a fix for [events.py line 190](https://github.com/llazzaro/django-scheduler/blob/develop/schedule/models/events.py#L190) which sometimes cause offset-aware dates to compare to offset-naive leading to a TypeError.