### PR TITLE
Fixes _get_occurrence_list

### DIFF
--- a/schedule/models/events.py
+++ b/schedule/models/events.py
@@ -220,9 +220,10 @@ class Event(with_metaclass(ModelBase, *get_model_bases())):
 
     def _get_occurrence_list(self, start, end):
         """
-        returns a list of occurrences for this event from start to end.
+        Returns a list of occurrences that fall completely or partially inside
+        the timespan defined by start (inclusive) and end (exclusive)
         """
-        difference = (self.end - self.start)
+        duration = self.end - self.start
         if self.rule is not None:
             use_naive = timezone.is_naive(start)
 
@@ -235,24 +236,36 @@ class Event(with_metaclass(ModelBase, *get_model_bases())):
             if self.end_recurring_period and self.end_recurring_period < end:
                 end = self.end_recurring_period
 
-            rule = self.get_rrule_object(tzinfo)
-            start = (start - difference).replace(tzinfo=None)
-            end = (end - difference)
+            start_rule = self.get_rrule_object(tzinfo)
+            start = start.replace(tzinfo=None)
             if timezone.is_aware(end):
                 end = tzinfo.normalize(end).replace(tzinfo=None)
+
             o_starts = []
-            o_starts.append(rule.between(start, end, inc=True))
-            o_starts.append(rule.between(start - (difference // 2), end - (difference // 2), inc=True))
-            o_starts.append(rule.between(start - difference, end - difference, inc=True))
-            for occ in o_starts:
-                for o_start in occ:
-                    o_start = tzinfo.localize(o_start)
-                    if use_naive:
-                        o_start = timezone.make_naive(o_start, tzinfo)
-                    o_end = o_start + difference
-                    occurrence = self._create_occurrence(o_start, o_end)
-                    if occurrence not in occurrences:
-                        occurrences.append(occurrence)
+
+            # Occurrences that start before the timespan but ends inside or after timespan
+            closest_start = start_rule.before(start, inc=False)
+            if closest_start is not None and closest_start + duration > start:
+                o_starts.append(closest_start)
+
+            # Occurences that happen between timespan (end-inclusive)
+            occs = start_rule.between(start, end, inc=True)
+            # Occurence that start on the end of timespan is potentially
+            # included above, lets remove it if thats the case
+            if len(occs) > 0:
+                if occs[-1:][0] == end:
+                    occs.pop()
+            # Add the occurrences we found
+            o_starts.extend(occs)
+
+            for o_start in o_starts:
+                o_start = tzinfo.localize(o_start)
+                if use_naive:
+                    o_start = timezone.make_naive(o_start, tzinfo)
+                o_end = o_start + duration
+                occurrence = self._create_occurrence(o_start, o_end)
+                if occurrence not in occurrences:
+                    occurrences.append(occurrence)
             return occurrences
         else:
             # check if event is in the period

--- a/schedule/models/events.py
+++ b/schedule/models/events.py
@@ -223,7 +223,7 @@ class Event(with_metaclass(ModelBase, *get_model_bases())):
         Returns a list of occurrences that fall completely or partially inside
         the timespan defined by start (inclusive) and end (exclusive)
         """
-        duration = self.end - self.start
+        duration = (self.end - self.start)
         if self.rule is not None:
             use_naive = timezone.is_naive(start)
 
@@ -243,14 +243,14 @@ class Event(with_metaclass(ModelBase, *get_model_bases())):
 
             o_starts = []
 
-            # Occurrences that start before the timespan but ends inside or after timespan
+            # Occurrences that start before the time span but ends inside or after timespan
             closest_start = start_rule.before(start, inc=False)
             if closest_start is not None and closest_start + duration > start:
                 o_starts.append(closest_start)
-
-            # Occurences that happen between timespan (end-inclusive)
+            
+            # Occurences that happen between time span (end-inclusive)
             occs = start_rule.between(start, end, inc=True)
-            # Occurence that start on the end of timespan is potentially
+            # Occurence that start on the end of time span is potentially
             # included above, lets remove it if thats the case
             if len(occs) > 0:
                 if occs[-1:][0] == end:

--- a/schedule/models/events.py
+++ b/schedule/models/events.py
@@ -254,7 +254,7 @@ class Event(with_metaclass(ModelBase, *get_model_bases())):
             # The occurrence that start on the end of the timespan is potentially
             # included above, lets remove if thats the case.
             if len(occs) > 0:
-                if occs[-1:][0] == end:
+                if occs[-1] == end:
                     occs.pop()
             # Add the occurrences found inside timespan
             o_starts.extend(occs)

--- a/schedule/periods.py
+++ b/schedule/periods.py
@@ -88,10 +88,6 @@ class Period(object):
         except AttributeError:
             prefetch_related_objects(self.events, ['occurrence_set'])
         for event in self.events:
-            #intersted = datetime.datetime(year=2017, month=1, day=3, hour=23, minute=15, tzinfo=pytz.utc)
-            #if intersted == self.start:
-            #    import ipdb
-            #    ipdb.set_trace()
             event_occurrences = event.get_occurrences(self.start, self.end, clear_prefetch=False)
             occurrences += event_occurrences
         return sorted(occurrences)

--- a/schedule/periods.py
+++ b/schedule/periods.py
@@ -88,6 +88,10 @@ class Period(object):
         except AttributeError:
             prefetch_related_objects(self.events, ['occurrence_set'])
         for event in self.events:
+            #intersted = datetime.datetime(year=2017, month=1, day=3, hour=23, minute=15, tzinfo=pytz.utc)
+            #if intersted == self.start:
+            #    import ipdb
+            #    ipdb.set_trace()
             event_occurrences = event.get_occurrences(self.start, self.end, clear_prefetch=False)
             occurrences += event_occurrences
         return sorted(occurrences)

--- a/schedule/templates/schedule/calendar_day.html
+++ b/schedule/templates/schedule/calendar_day.html
@@ -28,10 +28,6 @@
     <div>
       {% daily_table period %}
     </div>
-
-    <div>
-      {% daily_table period %}
-    </div>
 </div>
 
 {% endblock %}

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -467,9 +467,9 @@ class TestEvent(TestCase):
         self.assertEqual(occurrences[-1].end, end_recurring)
 
     @override_settings(USE_TZ=False)
-    def test_get_occurrences_timespan_inside_occurence(self):
+    def test_get_occurrences_timespan_inside_occurrence(self):
         ''' 
-        Test whether occurences are correctly obtained if selected timespan start
+        Test whether occurrences are correctly obtained if selected timespan start
         and end happen completely inside an occurence.
         '''
         cal = Calendar(name="MyCal")
@@ -492,9 +492,9 @@ class TestEvent(TestCase):
                 ['2008-01-12 08:00:00 to 2008-01-12 09:00:00'])
  
     @override_settings(USE_TZ=False)
-    def test_get_occurrences_timespan_partially_inside_occurence(self):
+    def test_get_occurrences_timespan_partially_inside_occurrence(self):
         ''' 
-        Test whether occurences are correctly obtained if selected timespan start
+        Test whether occurrences are correctly obtained if selected timespan start
         outside of timepan but ends inside occurrence.
         '''
         cal = Calendar(name="MyCal")
@@ -509,12 +509,51 @@ class TestEvent(TestCase):
                                     rule,
                                     cal
                 )
-        occurrences = recurring_event.get_occurrences(
+        occs1 = recurring_event.get_occurrences(
                                     start=datetime.datetime(2006, 1, 1, 0, 0),
                                     end=datetime.datetime(2008, 1, 19, 8, 30))
 
-        self.assertEqual(["%s to %s" %(o.start, o.end) for o in occurrences],
+        self.assertEqual(["%s to %s" %(o.start, o.end) for o in occs1],
                 ['2008-01-05 08:00:00 to 2008-01-05 09:00:00', '2008-01-12 08:00:00 to 2008-01-12 09:00:00', '2008-01-19 08:00:00 to 2008-01-19 09:00:00'])
+ 
+        occs2 = recurring_event.get_occurrences(
+                                    start=datetime.datetime(2006, 1, 1, 0, 0),
+                                    end=datetime.datetime(2008, 1, 19, 10, 0))
+
+        self.assertEqual(["%s to %s" %(o.start, o.end) for o in occs2],
+                ['2008-01-05 08:00:00 to 2008-01-05 09:00:00', '2008-01-12 08:00:00 to 2008-01-12 09:00:00', '2008-01-19 08:00:00 to 2008-01-19 09:00:00'])
+
+    @override_settings(USE_TZ=False)
+    def test_get_occurrences_timespan_edge_cases(self):
+        ''' 
+        Test whether occurrence list get method behave when requesting them on
+        timespan limits
+        '''
+        cal = Calendar(name="MyCal")
+        rule = Rule(frequency = "WEEKLY")
+        rule.save()
+
+        recurring_event = self.__create_recurring_event(
+                                    'Recurring event test',
+                                    datetime.datetime(2008, 1, 5, 8, 0),
+                                    datetime.datetime(2008, 1, 5, 9, 0),
+                                    datetime.datetime(2008, 5, 5, 0, 0),
+                                    rule,
+                                    cal
+                )
+        occs1 = recurring_event.get_occurrences(
+                                    start=datetime.datetime(2008, 1, 5, 8, 0),
+                                    end=datetime.datetime(2008, 1, 5, 8, 30))
+
+        self.assertEqual(["%s to %s" %(o.start, o.end) for o in occs1],
+                ['2008-01-05 08:00:00 to 2008-01-05 09:00:00'])
+
+        occs2 = recurring_event.get_occurrences(
+                                    start=datetime.datetime(2008, 1, 5, 7, 0),
+                                    end=datetime.datetime(2008, 1, 5, 8, 0))
+
+        self.assertEqual(["%s to %s" %(o.start, o.end) for o in occs2], [])
+ 
 
 class TestEventRelationManager(TestCase):
 

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -254,7 +254,7 @@ class TestEvent(TestCase):
         self.assertIsNone(event.get_occurrence(naive_date))
 
     # FIXME: This test gives an error
-    '''
+    
     @override_settings(USE_TZ=False)
     def test_get_occurrences_when_tz_off(self):
         cal = Calendar(name="MyCal")
@@ -269,13 +269,13 @@ class TestEvent(TestCase):
                                     rule,
                                     cal
                 )
-        #occurrences = recurring_event.get_occurrences(
-                                    #start=datetime.datetime(2008, 1, 12, 0, 0),
-                                    #end=datetime.datetime(2008, 1, 20, 0, 0))
+        occurrences = recurring_event.get_occurrences(
+                                    start=datetime.datetime(2008, 1, 12, 0, 0),
+                                    end=datetime.datetime(2008, 1, 20, 0, 0))
 
-        #self.assertEqual(["%s to %s" %(o.start, o.end) for o in occurrences],
-                #['2008-01-12 08:00:00 to 2008-01-12 09:00:00', '2008-01-19 08:00:00 to 2008-01-19 09:00:00'])
-    '''
+        self.assertEqual(["%s to %s" %(o.start, o.end) for o in occurrences],
+                ['2008-01-12 08:00:00 to 2008-01-12 09:00:00', '2008-01-19 08:00:00 to 2008-01-19 09:00:00'])
+    
 
     def test_event_get_ocurrence(self):
 

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -164,7 +164,7 @@ class TestEvent(TestCase):
         occurrences = recurring_event.get_occurrences(start=datetime.datetime(2008, 1, 5, tzinfo=pytz.utc),
            end = datetime.datetime(2008, 1, 6, tzinfo=pytz.utc))
         occurrence = occurrences[0]
-        occurrence2 = recurring_event.occurrences_after(datetime.datetime(2008, 1, 5, tzinfo=pytz.utc)).next()
+        occurrence2 = next(recurring_event.occurrences_after(datetime.datetime(2008, 1, 5, tzinfo=pytz.utc)))
         self.assertEqual(occurrence, occurrence2)
 
     def test_recurring_event_with_moved_get_occurrences_after(self):

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -161,11 +161,11 @@ class TestEvent(TestCase):
                     )
 
         recurring_event.save()
-        # occurrences = recurring_event.get_occurrences(start=datetime.datetime(2008, 1, 5, tzinfo=pytz.utc),
-        #    end = datetime.datetime(2008, 1, 6, tzinfo=pytz.utc))
-        # occurrence = occurrences[0]
-        # occurrence2 = recurring_event.occurrences_after(datetime.datetime(2008, 1, 5, tzinfo=pytz.utc)).next()
-        # self.assertEqual(occurrence, occurrence2)
+        occurrences = recurring_event.get_occurrences(start=datetime.datetime(2008, 1, 5, tzinfo=pytz.utc),
+           end = datetime.datetime(2008, 1, 6, tzinfo=pytz.utc))
+        occurrence = occurrences[0]
+        occurrence2 = recurring_event.occurrences_after(datetime.datetime(2008, 1, 5, tzinfo=pytz.utc)).next()
+        self.assertEqual(occurrence, occurrence2)
 
     def test_recurring_event_with_moved_get_occurrences_after(self):
 
@@ -253,8 +253,6 @@ class TestEvent(TestCase):
         naive_date = datetime.datetime(2008, 1, 20, 0, 0)
         self.assertIsNone(event.get_occurrence(naive_date))
 
-    # FIXME: This test gives an error
-    
     @override_settings(USE_TZ=False)
     def test_get_occurrences_when_tz_off(self):
         cal = Calendar(name="MyCal")

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -466,7 +466,55 @@ class TestEvent(TestCase):
         )
         self.assertEqual(occurrences[-1].end, end_recurring)
 
+    @override_settings(USE_TZ=False)
+    def test_get_occurrences_timespan_inside_occurence(self):
+        ''' 
+        Test whether occurences are correctly obtained if selected timespan start
+        and end happen completely inside an occurence.
+        '''
+        cal = Calendar(name="MyCal")
+        rule = Rule(frequency = "WEEKLY")
+        rule.save()
 
+        recurring_event = self.__create_recurring_event(
+                                    'Recurring event test',
+                                    datetime.datetime(2008, 1, 5, 8, 0),
+                                    datetime.datetime(2008, 1, 5, 9, 0),
+                                    datetime.datetime(2008, 5, 5, 0, 0),
+                                    rule,
+                                    cal
+                )
+        occurrences = recurring_event.get_occurrences(
+                                    start=datetime.datetime(2008, 1, 12, 8, 15),
+                                    end=datetime.datetime(2008, 1, 12, 8, 30))
+
+        self.assertEqual(["%s to %s" %(o.start, o.end) for o in occurrences],
+                ['2008-01-12 08:00:00 to 2008-01-12 09:00:00'])
+ 
+    @override_settings(USE_TZ=False)
+    def test_get_occurrences_timespan_partially_inside_occurence(self):
+        ''' 
+        Test whether occurences are correctly obtained if selected timespan start
+        outside of timepan but ends inside occurrence.
+        '''
+        cal = Calendar(name="MyCal")
+        rule = Rule(frequency = "WEEKLY")
+        rule.save()
+
+        recurring_event = self.__create_recurring_event(
+                                    'Recurring event test',
+                                    datetime.datetime(2008, 1, 5, 8, 0),
+                                    datetime.datetime(2008, 1, 5, 9, 0),
+                                    datetime.datetime(2008, 5, 5, 0, 0),
+                                    rule,
+                                    cal
+                )
+        occurrences = recurring_event.get_occurrences(
+                                    start=datetime.datetime(2006, 1, 1, 0, 0),
+                                    end=datetime.datetime(2008, 1, 19, 8, 30))
+
+        self.assertEqual(["%s to %s" %(o.start, o.end) for o in occurrences],
+                ['2008-01-05 08:00:00 to 2008-01-05 09:00:00', '2008-01-12 08:00:00 to 2008-01-12 09:00:00', '2008-01-19 08:00:00 to 2008-01-19 09:00:00'])
 
 class TestEventRelationManager(TestCase):
 

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -467,9 +467,6 @@ class TestEvent(TestCase):
         self.assertEqual(occurrences[-1].end, end_recurring)
 
 
-    def test_(self):
-        pass
-
 
 class TestEventRelationManager(TestCase):
 

--- a/tests/test_occurrence.py
+++ b/tests/test_occurrence.py
@@ -33,7 +33,7 @@ class TestOccurrence(TestCase):
         self.start = datetime.datetime(2008, 1, 12, 0, 0, tzinfo=pytz.utc)
         self.end = datetime.datetime(2008, 1, 27, 0, 0, tzinfo=pytz.utc)
 
-    def test_presisted_occurrences(self):
+    def test_persisted_occurrences(self):
         occurrences = self.recurring_event.get_occurrences(start=self.start, end=self.end)
         persisted_occurrence = occurrences[0]
         persisted_occurrence.save()


### PR DESCRIPTION
The method in charge of returning the occurrences of an event is basically broken. Due to its current logic the procedure tries to find occurrences checking for starts using a fixed time window based on the duration of the events. This method fails to find any occurrences if the timespan is either too small compared to the duration of the event or the time-span to check occurrences is too large and starts long before an occurrence. This makes it basically unusable in almost any scenario but the most basic one, event visualizations in the calendar GUI is the most notorious symptom of this problem if you choose smaller slot increments, but this has more deep implications. This PR tries to fix that.

The method now returns all occurrences of an event that happen inside the provided timespan, end-datetime exclusive. This means that if and event ends exactly on the provided end datetime it will not be returned as part of the list. This is to accommodate the more natural way of working with recurrent events and avoid duplication of occurrences due to overlapping (think about hourly recurring events of 1 hour duration). This PR includes new tests for the new logic and also uncomments previously created tests that were failing.