### PR TITLE
Fix Rule params handling

### DIFF
--- a/schedule/models/events.py
+++ b/schedule/models/events.py
@@ -220,9 +220,10 @@ class Event(with_metaclass(ModelBase, *get_model_bases())):
 
     def _get_occurrence_list(self, start, end):
         """
-        returns a list of occurrences for this event from start to end.
+        Returns a list of occurrences that fall completely or partially inside
+        the timespan defined by start (inclusive) and end (exclusive)
         """
-        difference = (self.end - self.start)
+        duration = self.end - self.start
         if self.rule is not None:
             use_naive = timezone.is_naive(start)
 
@@ -235,24 +236,36 @@ class Event(with_metaclass(ModelBase, *get_model_bases())):
             if self.end_recurring_period and self.end_recurring_period < end:
                 end = self.end_recurring_period
 
-            rule = self.get_rrule_object(tzinfo)
-            start = (start - difference).replace(tzinfo=None)
-            end = (end - difference)
+            start_rule = self.get_rrule_object(tzinfo)
+            start = start.replace(tzinfo=None)
             if timezone.is_aware(end):
                 end = tzinfo.normalize(end).replace(tzinfo=None)
+
             o_starts = []
-            o_starts.append(rule.between(start, end, inc=True))
-            o_starts.append(rule.between(start - (difference // 2), end - (difference // 2), inc=True))
-            o_starts.append(rule.between(start - difference, end - difference, inc=True))
-            for occ in o_starts:
-                for o_start in occ:
-                    o_start = tzinfo.localize(o_start)
-                    if use_naive:
-                        o_start = timezone.make_naive(o_start, tzinfo)
-                    o_end = o_start + difference
-                    occurrence = self._create_occurrence(o_start, o_end)
-                    if occurrence not in occurrences:
-                        occurrences.append(occurrence)
+
+            # Occurrences that start before the timespan but ends inside or after timespan
+            closest_start = start_rule.before(start, inc=False)
+            if closest_start is not None and closest_start + duration > start:
+                o_starts.append(closest_start)
+
+            # Occurences that happen between timespan (end-inclusive)
+            occs = start_rule.between(start, end, inc=True)
+            # Occurence that start on the end of timespan is potentially
+            # included above, lets remove it if thats the case
+            if len(occs) > 0:
+                if occs[-1:][0] == end:
+                    occs.pop()
+            # Add the occurrences we found
+            o_starts.extend(occs)
+
+            for o_start in o_starts:
+                o_start = tzinfo.localize(o_start)
+                if use_naive:
+                    o_start = timezone.make_naive(o_start, tzinfo)
+                o_end = o_start + duration
+                occurrence = self._create_occurrence(o_start, o_end)
+                if occurrence not in occurrences:
+                    occurrences.append(occurrence)
             return occurrences
         else:
             # check if event is in the period

--- a/schedule/models/events.py
+++ b/schedule/models/events.py
@@ -221,7 +221,7 @@ class Event(with_metaclass(ModelBase, *get_model_bases())):
         the timespan defined by start (inclusive) and end (exclusive)
         """
         if self.rule is not None:
-            duration = (self.end - self.start)
+            duration = self.end - self.start
             use_naive = timezone.is_naive(start)
 
             # Use the timezone from the start date
@@ -355,9 +355,7 @@ class Event(with_metaclass(ModelBase, *get_model_bases())):
             if (param in param_dict_order and param_dict_order[param] > freq_order and
                     param in start_params):
                 sp = start_params[param]
-                if hasattr(rule_params[param], '__iter__') and sp in rule_params[param]:
-                    event_params[param] = [sp]
-                elif sp == rule_params[param]:
+                if sp == rule_params[param] or (hasattr(rule_params[param], '__iter__') and sp in rule_params[param]):
                     event_params[param] = [sp]
                 else:
                     event_params[param] = rule_params[param]
@@ -369,7 +367,6 @@ class Event(with_metaclass(ModelBase, *get_model_bases())):
 
     @property
     def event_params(self):
-        #event_params, empty = self._event_params()
         event_params = self._event_params()
         start = self.effective_start
         if not start:

--- a/schedule/models/events.py
+++ b/schedule/models/events.py
@@ -178,19 +178,16 @@ class Event(with_metaclass(ModelBase, *get_model_bases())):
         return final_occurrences
 
     def get_rrule_object(self, tzinfo):
-        if self.rule is not None:
-            params, empty = self._event_params()
-            frequency = self.rule.rrule_frequency()
-            if timezone.is_naive(self.start):
-                dtstart = self.start
-            else:
-                dtstart = tzinfo.normalize(self.start).replace(tzinfo=None)
+        if self.rule is None:
+            return 
+        params = self._event_params()
+        frequency = self.rule.rrule_frequency()
+        if timezone.is_naive(self.start):
+            dtstart = self.start
+        else:
+            dtstart = tzinfo.normalize(self.start).replace(tzinfo=None)
 
-            if not empty:
-                return rrule.rrule(frequency, dtstart=dtstart, **params)
-            else:
-                year = self.start.year - 1
-                return rrule.rrule(frequency, dtstart=dtstart, until=self.start.replace(year=year))
+        return rrule.rrule(frequency, dtstart=dtstart, **params)
 
     def _create_occurrence(self, start, end=None):
         if end is None:
@@ -347,28 +344,33 @@ class Event(with_metaclass(ModelBase, *get_model_bases())):
         freq_order = freq_dict_order[self.rule.frequency]
         rule_params = self.event_rule_params
         start_params = self.event_start_params
-        empty = False
-
         event_params = {}
+
+        if len(rule_params) == 0:
+            event_params['count'] = 0
+            return event_params
 
         for param in rule_params:
             # start date influences rule params
             if (param in param_dict_order and param_dict_order[param] > freq_order and
                     param in start_params):
                 sp = start_params[param]
-                if sp == rule_params[param] or sp in rule_params[param]:
+                if hasattr(rule_params[param], '__iter__') and sp in rule_params[param]:
+                    event_params[param] = [sp]
+                elif sp == rule_params[param]:
                     event_params[param] = [sp]
                 else:
-                    event_params = {'count': 0}
-                    empty = True
-                    break
+                    event_params[param] = rule_params[param]
             else:
                 event_params[param] = rule_params[param]
-        return event_params, empty
+
+
+        return event_params
 
     @property
     def event_params(self):
-        event_params, empty = self._event_params()
+        #event_params, empty = self._event_params()
+        event_params = self._event_params()
         start = self.effective_start
         if not start:
             empty = True

--- a/schedule/models/events.py
+++ b/schedule/models/events.py
@@ -355,7 +355,9 @@ class Event(with_metaclass(ModelBase, *get_model_bases())):
             if (param in param_dict_order and param_dict_order[param] > freq_order and
                     param in start_params):
                 sp = start_params[param]
-                if sp == rule_params[param] or (hasattr(rule_params[param], '__iter__') and sp in rule_params[param]):
+                if sp == rule_params[param] or (
+                        hasattr(rule_params[param], '__iter__')
+                        and sp in rule_params[param]):
                     event_params[param] = [sp]
                 else:
                     event_params[param] = rule_params[param]

--- a/schedule/models/events.py
+++ b/schedule/models/events.py
@@ -223,7 +223,7 @@ class Event(with_metaclass(ModelBase, *get_model_bases())):
         Returns a list of occurrences that fall completely or partially inside
         the timespan defined by start (inclusive) and end (exclusive)
         """
-        duration = self.end - self.start
+        duration = (self.end - self.start)
         if self.rule is not None:
             use_naive = timezone.is_naive(start)
 
@@ -243,14 +243,14 @@ class Event(with_metaclass(ModelBase, *get_model_bases())):
 
             o_starts = []
 
-            # Occurrences that start before the timespan but ends inside or after timespan
+            # Occurrences that start before the time span but ends inside or after timespan
             closest_start = start_rule.before(start, inc=False)
             if closest_start is not None and closest_start + duration > start:
                 o_starts.append(closest_start)
-
-            # Occurences that happen between timespan (end-inclusive)
+            
+            # Occurences that happen between time span (end-inclusive)
             occs = start_rule.between(start, end, inc=True)
-            # Occurence that start on the end of timespan is potentially
+            # Occurence that start on the end of time span is potentially
             # included above, lets remove it if thats the case
             if len(occs) > 0:
                 if occs[-1:][0] == end:

--- a/schedule/models/events.py
+++ b/schedule/models/events.py
@@ -254,7 +254,7 @@ class Event(with_metaclass(ModelBase, *get_model_bases())):
             # The occurrence that start on the end of the timespan is potentially
             # included above, lets remove if thats the case.
             if len(occs) > 0:
-                if occs[-1:][0] == end:
+                if occs[-1] == end:
                     occs.pop()
             # Add the occurrences found inside timespan
             o_starts.extend(occs)

--- a/schedule/models/rules.py
+++ b/schedule/models/rules.py
@@ -98,10 +98,12 @@ class Rule(with_metaclass(ModelBase, *get_model_bases())):
             param = param.split(':')
             if len(param) != 2:
                 continue
-            param = (str(param[0]), [ x for x in [self._weekday_or_number(p) for p in param[1].split(',')] if x is not None])
+            param = (str(param[0]), [ x for x in
+                [self._weekday_or_number(v) for v in param[1].split(',')]
+                if x is not None])
             if len(param[1]) == 1:
                  param_value = self._weekday_or_number(param[1][0])
-                 param = (param[0], param_value) 
+                 param = (param[0], param_value)
             param_dict.append(param)
         return dict(param_dict)
 

--- a/schedule/periods.py
+++ b/schedule/periods.py
@@ -88,10 +88,6 @@ class Period(object):
         except AttributeError:
             prefetch_related_objects(self.events, ['occurrence_set'])
         for event in self.events:
-            #intersted = datetime.datetime(year=2017, month=1, day=3, hour=23, minute=15, tzinfo=pytz.utc)
-            #if intersted == self.start:
-            #    import ipdb
-            #    ipdb.set_trace()
             event_occurrences = event.get_occurrences(self.start, self.end, clear_prefetch=False)
             occurrences += event_occurrences
         return sorted(occurrences)

--- a/schedule/periods.py
+++ b/schedule/periods.py
@@ -88,6 +88,10 @@ class Period(object):
         except AttributeError:
             prefetch_related_objects(self.events, ['occurrence_set'])
         for event in self.events:
+            #intersted = datetime.datetime(year=2017, month=1, day=3, hour=23, minute=15, tzinfo=pytz.utc)
+            #if intersted == self.start:
+            #    import ipdb
+            #    ipdb.set_trace()
             event_occurrences = event.get_occurrences(self.start, self.end, clear_prefetch=False)
             occurrences += event_occurrences
         return sorted(occurrences)

--- a/schedule/templates/schedule/calendar_day.html
+++ b/schedule/templates/schedule/calendar_day.html
@@ -28,10 +28,6 @@
     <div>
       {% daily_table period %}
     </div>
-
-    <div>
-      {% daily_table period %}
-    </div>
 </div>
 
 {% endblock %}

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -467,9 +467,9 @@ class TestEvent(TestCase):
         self.assertEqual(occurrences[-1].end, end_recurring)
 
     @override_settings(USE_TZ=False)
-    def test_get_occurrences_timespan_inside_occurence(self):
+    def test_get_occurrences_timespan_inside_occurrence(self):
         ''' 
-        Test whether occurences are correctly obtained if selected timespan start
+        Test whether occurrences are correctly obtained if selected timespan start
         and end happen completely inside an occurence.
         '''
         cal = Calendar(name="MyCal")
@@ -492,9 +492,9 @@ class TestEvent(TestCase):
                 ['2008-01-12 08:00:00 to 2008-01-12 09:00:00'])
  
     @override_settings(USE_TZ=False)
-    def test_get_occurrences_timespan_partially_inside_occurence(self):
+    def test_get_occurrences_timespan_partially_inside_occurrence(self):
         ''' 
-        Test whether occurences are correctly obtained if selected timespan start
+        Test whether occurrences are correctly obtained if selected timespan start
         outside of timepan but ends inside occurrence.
         '''
         cal = Calendar(name="MyCal")
@@ -509,12 +509,51 @@ class TestEvent(TestCase):
                                     rule,
                                     cal
                 )
-        occurrences = recurring_event.get_occurrences(
+        occs1 = recurring_event.get_occurrences(
                                     start=datetime.datetime(2006, 1, 1, 0, 0),
                                     end=datetime.datetime(2008, 1, 19, 8, 30))
 
-        self.assertEqual(["%s to %s" %(o.start, o.end) for o in occurrences],
+        self.assertEqual(["%s to %s" %(o.start, o.end) for o in occs1],
                 ['2008-01-05 08:00:00 to 2008-01-05 09:00:00', '2008-01-12 08:00:00 to 2008-01-12 09:00:00', '2008-01-19 08:00:00 to 2008-01-19 09:00:00'])
+ 
+        occs2 = recurring_event.get_occurrences(
+                                    start=datetime.datetime(2006, 1, 1, 0, 0),
+                                    end=datetime.datetime(2008, 1, 19, 10, 0))
+
+        self.assertEqual(["%s to %s" %(o.start, o.end) for o in occs2],
+                ['2008-01-05 08:00:00 to 2008-01-05 09:00:00', '2008-01-12 08:00:00 to 2008-01-12 09:00:00', '2008-01-19 08:00:00 to 2008-01-19 09:00:00'])
+
+    @override_settings(USE_TZ=False)
+    def test_get_occurrences_timespan_edge_cases(self):
+        ''' 
+        Test whether occurrence list get method behave when requesting them on
+        timespan limits
+        '''
+        cal = Calendar(name="MyCal")
+        rule = Rule(frequency = "WEEKLY")
+        rule.save()
+
+        recurring_event = self.__create_recurring_event(
+                                    'Recurring event test',
+                                    datetime.datetime(2008, 1, 5, 8, 0),
+                                    datetime.datetime(2008, 1, 5, 9, 0),
+                                    datetime.datetime(2008, 5, 5, 0, 0),
+                                    rule,
+                                    cal
+                )
+        occs1 = recurring_event.get_occurrences(
+                                    start=datetime.datetime(2008, 1, 5, 8, 0),
+                                    end=datetime.datetime(2008, 1, 5, 8, 30))
+
+        self.assertEqual(["%s to %s" %(o.start, o.end) for o in occs1],
+                ['2008-01-05 08:00:00 to 2008-01-05 09:00:00'])
+
+        occs2 = recurring_event.get_occurrences(
+                                    start=datetime.datetime(2008, 1, 5, 7, 0),
+                                    end=datetime.datetime(2008, 1, 5, 8, 0))
+
+        self.assertEqual(["%s to %s" %(o.start, o.end) for o in occs2], [])
+ 
 
 class TestEventRelationManager(TestCase):
 

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -254,7 +254,7 @@ class TestEvent(TestCase):
         self.assertIsNone(event.get_occurrence(naive_date))
 
     # FIXME: This test gives an error
-    '''
+    
     @override_settings(USE_TZ=False)
     def test_get_occurrences_when_tz_off(self):
         cal = Calendar(name="MyCal")
@@ -269,13 +269,13 @@ class TestEvent(TestCase):
                                     rule,
                                     cal
                 )
-        #occurrences = recurring_event.get_occurrences(
-                                    #start=datetime.datetime(2008, 1, 12, 0, 0),
-                                    #end=datetime.datetime(2008, 1, 20, 0, 0))
+        occurrences = recurring_event.get_occurrences(
+                                    start=datetime.datetime(2008, 1, 12, 0, 0),
+                                    end=datetime.datetime(2008, 1, 20, 0, 0))
 
-        #self.assertEqual(["%s to %s" %(o.start, o.end) for o in occurrences],
-                #['2008-01-12 08:00:00 to 2008-01-12 09:00:00', '2008-01-19 08:00:00 to 2008-01-19 09:00:00'])
-    '''
+        self.assertEqual(["%s to %s" %(o.start, o.end) for o in occurrences],
+                ['2008-01-12 08:00:00 to 2008-01-12 09:00:00', '2008-01-19 08:00:00 to 2008-01-19 09:00:00'])
+    
 
     def test_event_get_ocurrence(self):
 

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -507,8 +507,8 @@ class TestEvent(TestCase):
                                     datetime.datetime(2008, 1, 5, 9, 0),
                                     datetime.datetime(2008, 5, 5, 0, 0),
                                     rule,
-                                    cal
-                )
+                                    cal)
+
         occs1 = recurring_event.get_occurrences(
                                     start=datetime.datetime(2006, 1, 1, 0, 0),
                                     end=datetime.datetime(2008, 1, 19, 8, 30))
@@ -539,8 +539,8 @@ class TestEvent(TestCase):
                                     datetime.datetime(2008, 1, 5, 9, 0),
                                     datetime.datetime(2008, 5, 5, 0, 0),
                                     rule,
-                                    cal
-                )
+                                    cal)
+
         occs1 = recurring_event.get_occurrences(
                                     start=datetime.datetime(2008, 1, 5, 8, 0),
                                     end=datetime.datetime(2008, 1, 5, 8, 30))
@@ -554,7 +554,46 @@ class TestEvent(TestCase):
 
         self.assertEqual(["%s to %s" %(o.start, o.end) for o in occs2], [])
 
+    @override_settings(USE_TZ=False)
+    def test_get_occurrences_rule_weekday_param(self):
+        ''' 
+        Test whether occurrence list get method behaves correctly while using
+        complex rule parameters
+        '''
+        cal = Calendar(name="MyCal")
+        # Last Fridays of each month
+        rule = Rule(frequency="MONTHLY", params='BYWEEKDAY:FR;BYSETPOS:-1')
+        rule.save()
 
+        recurring_event = self.__create_recurring_event(
+                                    'Last Friday of each month',
+                                    datetime.datetime(2016, 11, 1),
+                                    datetime.datetime(2016, 11, 1),
+                                    datetime.datetime(2030, 1, 1),
+                                    rule,
+                                    cal)
+
+        occs = recurring_event.get_occurrences(
+                                    start=datetime.datetime(2016, 11, 1),
+                                    end=datetime.datetime(2017, 12, 31))
+
+        self.assertEqual(["%s to %s" %(o.start, o.end) for o in occs],
+                ['2016-11-25 00:00:00 to 2016-11-25 00:00:00',
+                 '2016-12-30 00:00:00 to 2016-12-30 00:00:00',
+                 '2017-01-27 00:00:00 to 2017-01-27 00:00:00',
+                 '2017-02-24 00:00:00 to 2017-02-24 00:00:00',
+                 '2017-03-31 00:00:00 to 2017-03-31 00:00:00',
+                 '2017-04-28 00:00:00 to 2017-04-28 00:00:00',
+                 '2017-05-26 00:00:00 to 2017-05-26 00:00:00',
+                 '2017-06-30 00:00:00 to 2017-06-30 00:00:00',
+                 '2017-07-28 00:00:00 to 2017-07-28 00:00:00',
+                 '2017-08-25 00:00:00 to 2017-08-25 00:00:00',
+                 '2017-09-29 00:00:00 to 2017-09-29 00:00:00',
+                 '2017-10-27 00:00:00 to 2017-10-27 00:00:00',
+                 '2017-11-24 00:00:00 to 2017-11-24 00:00:00',
+                 '2017-12-29 00:00:00 to 2017-12-29 00:00:00'])
+
+ 
 class TestEventRelationManager(TestCase):
 
     def test_get_events_for_object(self):

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -164,7 +164,7 @@ class TestEvent(TestCase):
         occurrences = recurring_event.get_occurrences(start=datetime.datetime(2008, 1, 5, tzinfo=pytz.utc),
            end = datetime.datetime(2008, 1, 6, tzinfo=pytz.utc))
         occurrence = occurrences[0]
-        occurrence2 = recurring_event.occurrences_after(datetime.datetime(2008, 1, 5, tzinfo=pytz.utc)).next()
+        occurrence2 = next(recurring_event.occurrences_after(datetime.datetime(2008, 1, 5, tzinfo=pytz.utc)))
         self.assertEqual(occurrence, occurrence2)
 
     def test_recurring_event_with_moved_get_occurrences_after(self):

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -161,11 +161,11 @@ class TestEvent(TestCase):
                     )
 
         recurring_event.save()
-        # occurrences = recurring_event.get_occurrences(start=datetime.datetime(2008, 1, 5, tzinfo=pytz.utc),
-        #    end = datetime.datetime(2008, 1, 6, tzinfo=pytz.utc))
-        # occurrence = occurrences[0]
-        # occurrence2 = recurring_event.occurrences_after(datetime.datetime(2008, 1, 5, tzinfo=pytz.utc)).next()
-        # self.assertEqual(occurrence, occurrence2)
+        occurrences = recurring_event.get_occurrences(start=datetime.datetime(2008, 1, 5, tzinfo=pytz.utc),
+           end = datetime.datetime(2008, 1, 6, tzinfo=pytz.utc))
+        occurrence = occurrences[0]
+        occurrence2 = recurring_event.occurrences_after(datetime.datetime(2008, 1, 5, tzinfo=pytz.utc)).next()
+        self.assertEqual(occurrence, occurrence2)
 
     def test_recurring_event_with_moved_get_occurrences_after(self):
 
@@ -253,8 +253,6 @@ class TestEvent(TestCase):
         naive_date = datetime.datetime(2008, 1, 20, 0, 0)
         self.assertIsNone(event.get_occurrence(naive_date))
 
-    # FIXME: This test gives an error
-    
     @override_settings(USE_TZ=False)
     def test_get_occurrences_when_tz_off(self):
         cal = Calendar(name="MyCal")

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -466,7 +466,55 @@ class TestEvent(TestCase):
         )
         self.assertEqual(occurrences[-1].end, end_recurring)
 
+    @override_settings(USE_TZ=False)
+    def test_get_occurrences_timespan_inside_occurence(self):
+        ''' 
+        Test whether occurences are correctly obtained if selected timespan start
+        and end happen completely inside an occurence.
+        '''
+        cal = Calendar(name="MyCal")
+        rule = Rule(frequency = "WEEKLY")
+        rule.save()
 
+        recurring_event = self.__create_recurring_event(
+                                    'Recurring event test',
+                                    datetime.datetime(2008, 1, 5, 8, 0),
+                                    datetime.datetime(2008, 1, 5, 9, 0),
+                                    datetime.datetime(2008, 5, 5, 0, 0),
+                                    rule,
+                                    cal
+                )
+        occurrences = recurring_event.get_occurrences(
+                                    start=datetime.datetime(2008, 1, 12, 8, 15),
+                                    end=datetime.datetime(2008, 1, 12, 8, 30))
+
+        self.assertEqual(["%s to %s" %(o.start, o.end) for o in occurrences],
+                ['2008-01-12 08:00:00 to 2008-01-12 09:00:00'])
+ 
+    @override_settings(USE_TZ=False)
+    def test_get_occurrences_timespan_partially_inside_occurence(self):
+        ''' 
+        Test whether occurences are correctly obtained if selected timespan start
+        outside of timepan but ends inside occurrence.
+        '''
+        cal = Calendar(name="MyCal")
+        rule = Rule(frequency = "WEEKLY")
+        rule.save()
+
+        recurring_event = self.__create_recurring_event(
+                                    'Recurring event test',
+                                    datetime.datetime(2008, 1, 5, 8, 0),
+                                    datetime.datetime(2008, 1, 5, 9, 0),
+                                    datetime.datetime(2008, 5, 5, 0, 0),
+                                    rule,
+                                    cal
+                )
+        occurrences = recurring_event.get_occurrences(
+                                    start=datetime.datetime(2006, 1, 1, 0, 0),
+                                    end=datetime.datetime(2008, 1, 19, 8, 30))
+
+        self.assertEqual(["%s to %s" %(o.start, o.end) for o in occurrences],
+                ['2008-01-05 08:00:00 to 2008-01-05 09:00:00', '2008-01-12 08:00:00 to 2008-01-12 09:00:00', '2008-01-19 08:00:00 to 2008-01-19 09:00:00'])
 
 class TestEventRelationManager(TestCase):
 

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -553,7 +553,7 @@ class TestEvent(TestCase):
                                     end=datetime.datetime(2008, 1, 5, 8, 0))
 
         self.assertEqual(["%s to %s" %(o.start, o.end) for o in occs2], [])
- 
+
 
 class TestEventRelationManager(TestCase):
 

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -467,9 +467,6 @@ class TestEvent(TestCase):
         self.assertEqual(occurrences[-1].end, end_recurring)
 
 
-    def test_(self):
-        pass
-
 
 class TestEventRelationManager(TestCase):
 

--- a/tests/test_occurrence.py
+++ b/tests/test_occurrence.py
@@ -33,7 +33,7 @@ class TestOccurrence(TestCase):
         self.start = datetime.datetime(2008, 1, 12, 0, 0, tzinfo=pytz.utc)
         self.end = datetime.datetime(2008, 1, 27, 0, 0, tzinfo=pytz.utc)
 
-    def test_presisted_occurrences(self):
+    def test_persisted_occurrences(self):
         occurrences = self.recurring_event.get_occurrences(start=self.start, end=self.end)
         persisted_occurrence = occurrences[0]
         persisted_occurrence.save()

--- a/tests/test_rule.py
+++ b/tests/test_rule.py
@@ -8,6 +8,6 @@ class TestPeriod(TestCase):
         pass
 
     def test_get_params(self):
-        rule = Rule(params = "count:1;bysecond:1;byminute:1,2,4,5")
-        expected =  {'count': 1, 'byminute': [1, 2, 4, 5], 'bysecond': 1}
+        rule = Rule(params="count:1;bysecond:1;byminute:1,2,4,5;byday:FR;bysetpos:-1")
+        expected =  {'count': 1, 'byminute': [1, 2, 4, 5], 'bysecond': 1, 'byday': 'FR', 'bysetpos': -1}
         self.assertEqual(rule.get_params(), expected)

--- a/tests/test_rule.py
+++ b/tests/test_rule.py
@@ -1,6 +1,7 @@
 from django.test import TestCase
-
+from dateutil.rrule import FR
 from schedule.models import Rule
+
 
 class TestPeriod(TestCase):
 
@@ -8,6 +9,6 @@ class TestPeriod(TestCase):
         pass
 
     def test_get_params(self):
-        rule = Rule(params="count:1;bysecond:1;byminute:1,2,4,5;byday:FR;bysetpos:-1")
-        expected =  {'count': 1, 'byminute': [1, 2, 4, 5], 'bysecond': 1, 'byday': 'FR', 'bysetpos': -1}
+        rule = Rule(params="count:1;bysecond:1;byminute:1,2,4,5;byweekday:FR;bysetpos:-1")
+        expected =  {'count': 1, 'byminute': [1, 2, 4, 5], 'bysecond': 1, 'byweekday': FR, 'bysetpos': -1}
         self.assertEqual(rule.get_params(), expected)


### PR DESCRIPTION
Fixes:

* #29
* #264 
* #262 

Changes:

* Rules parameters now accept weekday strings  (MO, TU, TH, WE, FR, SA, SU) where appropriate. Internally these will be converted and used as ``dateutil.rrule`` constants.

* Removed some legacy code that made no sense to me and made the tests fail. Something tells me these were workarounds for edge cases with previous occurrence generation.

This PR includes changes from the ``fix_get_occurrences`` branch that is not yet merged and its a dependency for these changes. Once this base branch is merged to develop there should be less changes to go thru in this PR. (you can also compare the two branches to see the changes). Please review carefully.
