### PR TITLE
Fix view's get occurrence

### DIFF
--- a/schedule/models/events.py
+++ b/schedule/models/events.py
@@ -187,7 +187,9 @@ class Event(with_metaclass(ModelBase, *get_model_bases())):
         else:
             dtstart = tzinfo.normalize(self.start).replace(tzinfo=None)
 
-        if timezone.is_naive(self.end_recurring_period):
+        if self.end_recurring_period is None:
+            until = None
+        elif timezone.is_naive(self.end_recurring_period):
             until = self.end_recurring_period
         else:
             until = tzinfo.normalize(

--- a/schedule/models/events.py
+++ b/schedule/models/events.py
@@ -303,8 +303,6 @@ class Event(with_metaclass(ModelBase, *get_model_bases())):
         loop_counter = 0
         for o_start in date_iter:
             o_start = tzinfo.localize(o_start)
-            if self.end_recurring_period and self.end_recurring_period and o_start > self.end_recurring_period:
-                break
             o_end = o_start + difference
             if o_end > after:
                 yield self._create_occurrence(o_start, o_end)

--- a/schedule/models/events.py
+++ b/schedule/models/events.py
@@ -187,7 +187,13 @@ class Event(with_metaclass(ModelBase, *get_model_bases())):
         else:
             dtstart = tzinfo.normalize(self.start).replace(tzinfo=None)
 
-        return rrule.rrule(frequency, dtstart=dtstart, **params)
+        if timezone.is_naive(self.end_recurring_period):
+            until = self.end_recurring_period
+        else:
+            until = tzinfo.normalize(
+                    self.end_recurring_period.astimezone(tzinfo)).replace(tzinfo=None)
+
+        return rrule.rrule(frequency, dtstart=dtstart, until=until, **params)
 
     def _create_occurrence(self, start, end=None):
         if end is None:

--- a/schedule/views.py
+++ b/schedule/views.py
@@ -256,17 +256,14 @@ def get_occurrence(event_id, occurrence_id=None, year=None, month=None,
     retrieve it.  This function returns an event and occurrence regardless of
     which method is used.
     """
-    if tzinfo is None:
-        tzinfo = timezone.get_current_timezone()
-
     if(occurrence_id):
         occurrence = get_object_or_404(Occurrence, id=occurrence_id)
         event = occurrence.event
-    elif(all((year, month, day, hour, minute, second))):
+    elif None not in (year, month, day, hour, minute, second):
         event = get_object_or_404(Event, id=event_id)
-        date = tzinfo.localize(datetime.datetime(int(year), int(month),
-                               int(day), int(hour), int(minute),
-                               int(second)))
+        date = timezone.make_aware(datetime.datetime(int(year), int(month),
+                                   int(day), int(hour), int(minute),
+                                   int(second)), tzinfo)
         occurrence = event.get_occurrence(date)
         if occurrence is None:
             raise Http404

--- a/schedule/views.py
+++ b/schedule/views.py
@@ -266,7 +266,7 @@ def get_occurrence(event_id, occurrence_id=None, year=None, month=None,
         event = get_object_or_404(Event, id=event_id)
         date = tzinfo.localize(datetime.datetime(int(year), int(month),
                                int(day), int(hour), int(minute),
-                               int(second), tzinfo=tzinfo))
+                               int(second)))
         occurrence = event.get_occurrence(date)
         if occurrence is None:
             raise Http404

--- a/schedule/views.py
+++ b/schedule/views.py
@@ -264,9 +264,10 @@ def get_occurrence(event_id, occurrence_id=None, year=None, month=None,
         event = occurrence.event
     elif(all((year, month, day, hour, minute, second))):
         event = get_object_or_404(Event, id=event_id)
-        occurrence = event.get_occurrence(
-            datetime.datetime(int(year), int(month), int(day), int(hour),
-                              int(minute), int(second), tzinfo=tzinfo))
+        date = tzinfo.localize(datetime.datetime(int(year), int(month),
+                               int(day), int(hour), int(minute),
+                               int(second), tzinfo=tzinfo))
+        occurrence = event.get_occurrence(date)
         if occurrence is None:
             raise Http404
     else:

--- a/schedule/views.py
+++ b/schedule/views.py
@@ -248,7 +248,7 @@ class DeleteEventView(EventEditMixin, DeleteView):
 
 def get_occurrence(event_id, occurrence_id=None, year=None, month=None,
                    day=None, hour=None, minute=None, second=None,
-                   tzinfo=pytz.utc):
+                   tzinfo=None):
     """
     Because occurrences don't have to be persisted, there must be two ways to
     retrieve them. both need an event, but if its persisted the occurrence can
@@ -256,6 +256,9 @@ def get_occurrence(event_id, occurrence_id=None, year=None, month=None,
     retrieve it.  This function returns an event and occurrence regardless of
     which method is used.
     """
+    if tzinfo is None:
+        tzinfo = timezone.get_current_timezone()
+
     if(occurrence_id):
         occurrence = get_object_or_404(Occurrence, id=occurrence_id)
         event = occurrence.event

--- a/tests/test_periods.py
+++ b/tests/test_periods.py
@@ -391,7 +391,6 @@ class TestWeeklyOccurrences(TestCase):
         start = self.MVD.localize(datetime.datetime(2017, 1, 13))
 
         period = Week([event], start, tzinfo=self.MVD)
-        occs = period.occurrences
  
         self.assertEqual(["%s to %s" % (o.start, o.end) for o in period.occurrences],
                 ['2017-01-13 15:00:00-03:00 to 2017-01-14 15:00:00-03:00'])

--- a/tests/test_periods.py
+++ b/tests/test_periods.py
@@ -291,9 +291,6 @@ class TestOccurrencePool(TestCase):
 class TestOccurrencesInTimezone(TestCase):
 
     def setUp(self):
-        '''
-        Configures Django to use a timezone
-        '''
         self.MVD = pytz.timezone('America/Montevideo')
         cal = Calendar(name="MyCal")
         cal.save()
@@ -333,7 +330,42 @@ class TestOccurrencesInTimezone(TestCase):
         self.assertEqual(["%s to %s" % (o.start, o.end) for o in sub_period.occurrences],
                 ['2017-01-14 22:00:00-03:00 to 2017-01-14 23:00:00-03:00'])
 
- 
+class TestWeeklyOccurrences(TestCase):
+
+    def setUp(self):
+        self.MVD = pytz.timezone('America/Montevideo')  # UTC-3
+        cal = Calendar(name="MyCal")
+        cal.save()
+        rule = Rule(frequency="DAILY", name="daily")
+        rule.save()
+        data = {
+                'title': 'Test event',
+                'start': self.MVD.localize(datetime.datetime(2017, 1, 13, 15, 0)),
+                'end': self.MVD.localize(datetime.datetime(2017, 1, 14, 15, 0)),
+                'end_recurring_period' : self.MVD.localize(datetime.datetime(2017, 1, 20)),
+                'rule': rule,
+                'calendar': cal
+               }
+        recurring_event = Event(**data)
+        recurring_event.save()
+
+    def test_occurrences_inside_recurrence_period(self):
+        start = self.MVD.localize(datetime.datetime(2017, 1, 13))
+
+        period = Week(Event.objects.all(), start, tzinfo=self.MVD)
+
+        self.assertEqual(["%s to %s" % (o.start, o.end) for o in period.occurrences],
+                ['2017-01-13 15:00:00-03:00 to 2017-01-14 15:00:00-03:00',
+                 '2017-01-14 15:00:00-03:00 to 2017-01-15 15:00:00-03:00'])
+
+    def test_occurrences_outside_recurrence_period(self):
+        start = self.MVD.localize(datetime.datetime(2017, 1, 23))
+
+        period = Week(Event.objects.all(), start, tzinfo=self.MVD)
+
+        self.assertEqual(["%s to %s" % (o.start, o.end) for o in period.occurrences],
+                [])
+
 
 class TestAwareDay(TestCase):
     def setUp(self):

--- a/tests/test_periods.py
+++ b/tests/test_periods.py
@@ -366,7 +366,37 @@ class TestWeeklyOccurrences(TestCase):
         self.assertEqual(["%s to %s" % (o.start, o.end) for o in period.occurrences],
                 [])
 
+    def test_occurrences_no_end(self):
+        event = Event.objects.filter(title='Test event').get()
+        event.end_recurring_period = None
+        start = self.MVD.localize(datetime.datetime(2018, 1, 13))
 
+        period = Week([event], start, tzinfo=self.MVD)
+        occs = period.occurrences
+
+        self.assertEqual(["%s to %s" % (o.start, o.end) for o in period.occurrences],
+                ['2018-01-06 15:00:00-03:00 to 2018-01-07 15:00:00-03:00',
+                 '2018-01-07 15:00:00-03:00 to 2018-01-08 15:00:00-03:00',
+                 '2018-01-08 15:00:00-03:00 to 2018-01-09 15:00:00-03:00',
+                 '2018-01-09 15:00:00-03:00 to 2018-01-10 15:00:00-03:00',
+                 '2018-01-10 15:00:00-03:00 to 2018-01-11 15:00:00-03:00',
+                 '2018-01-11 15:00:00-03:00 to 2018-01-12 15:00:00-03:00',
+                 '2018-01-12 15:00:00-03:00 to 2018-01-13 15:00:00-03:00',
+                 '2018-01-13 15:00:00-03:00 to 2018-01-14 15:00:00-03:00'])
+ 
+    def test_occurrences_end_in_diff_tz(self):
+        event = Event.objects.filter(title='Test event').get()
+        AMSTERDAM = pytz.timezone('Europe/Amsterdam')
+        # 2017-01-14 00:00 CET = 2017-01-13 21:00 UYT
+        event.end_recurring_period = AMSTERDAM.localize(datetime.datetime(2017, 1, 14, 0, 0))
+        start = self.MVD.localize(datetime.datetime(2017, 1, 13))
+
+        period = Week([event], start, tzinfo=self.MVD)
+        occs = period.occurrences
+ 
+        self.assertEqual(["%s to %s" % (o.start, o.end) for o in period.occurrences],
+                ['2017-01-13 15:00:00-03:00 to 2017-01-14 15:00:00-03:00'])
+ 
 class TestAwareDay(TestCase):
     def setUp(self):
         self.timezone = pytz.timezone('Europe/Amsterdam')

--- a/tests/test_periods.py
+++ b/tests/test_periods.py
@@ -372,7 +372,6 @@ class TestWeeklyOccurrences(TestCase):
         start = self.MVD.localize(datetime.datetime(2018, 1, 13))
 
         period = Week([event], start, tzinfo=self.MVD)
-        occs = period.occurrences
 
         self.assertEqual(["%s to %s" % (o.start, o.end) for o in period.occurrences],
                 ['2018-01-06 15:00:00-03:00 to 2018-01-07 15:00:00-03:00',


### PR DESCRIPTION
get_occurrence function in views.py does not handle timezones correctly. A number of views use it, specially in the edition of occurrences. This PR fixes does issues. 

This is related to #289 but does not close it as there is a permission issue still needed to be resolved.