### PR TITLE
Replace deprecated [wheel] with [bdist_wheel] in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
+[bdist_wheel]
+universal = 1
+
 [flake8]
 exclude = docs
 ignore = E501
-
-[wheel]
-universal = 1


### PR DESCRIPTION
bdist_wheel is now the preferred name of the section. See:

https://bitbucket.org/pypa/wheel/src/54ddbcc9cec25e1f4d111a142b8bfaa163130a61/wheel/bdist_wheel.py?at=default&fileviewer=file-view-default#bdist_wheel.py-119:125