### PR TITLE
Allow additional fields to be added to admin forms

### DIFF
--- a/schedule/admin.py
+++ b/schedule/admin.py
@@ -2,6 +2,7 @@ from django.contrib import admin
 
 from schedule.forms import EventAdminForm
 from schedule.models import Calendar, CalendarRelation, Event, Occurrence, Rule
+from schedule.utils import get_admin_model_fields
 
 
 class CalendarAdminOptions(admin.ModelAdmin):
@@ -45,7 +46,7 @@ class EventAdmin(admin.ModelAdmin):
                 ('start', 'end'),
                 ('creator', 'calendar'),
                 ('rule', 'end_recurring_period'),
-            ]
+            ] + get_admin_model_fields('Event')
         }),
     )
     form = EventAdminForm

--- a/schedule/utils.py
+++ b/schedule/utils.py
@@ -247,3 +247,15 @@ def get_model_bases(model_class_name):
         return [import_string(x) for x in base_class_names]
     else:
         return [Model]
+
+
+def get_admin_model_fields(model_class_name):
+    admin_fields = getattr(settings, 'SCHEDULER_ADMIN_FIELDS', {})
+    if isinstance(admin_fields, dict):
+        model_fields = admin_fields.get(model_class_name, [])
+    else:
+        model_fields = admin_fields
+    if model_fields:
+        return model_fields
+    else:
+        return []

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,7 +6,8 @@ from django.utils import timezone
 
 from schedule.models import Calendar, Event, Occurrence, Rule
 from schedule.utils import (
-    EventListManager, OccurrenceReplacer, get_model_bases,
+    EventListManager, OccurrenceReplacer, get_admin_model_fields,
+    get_model_bases,
 )
 
 
@@ -190,3 +191,19 @@ class TestCommonUtils(TestCase):
         actual_result = get_model_bases('Event')
 
         self.assertListEqual(actual_result, expected_result)
+
+    @override_settings(SCHEDULER_ADMIN_FIELDS=[('cost',)])
+    def test_get_admin_fields_with_custom_list(self):
+        self.assertListEqual(get_admin_model_fields('Event'), [('cost',)])
+
+    @override_settings(SCHEDULER_ADMIN_FIELDS={'ClassName': [('cost',)]})
+    def test_get_admin_fields_with_custom_dict_specific(self):
+        self.assertListEqual(get_admin_model_fields('ClassName'), [('cost',)])
+
+    @override_settings(SCHEDULER_ADMIN_FIELDS={'ClassName': [('cost',)]})
+    def test_get_admin_fields_with_custom_dict_default(self):
+        self.assertListEqual(get_admin_model_fields('Event'), [])
+
+    @override_settings(SCHEDULER_ADMIN_FIELDS=None)
+    def test_get_admin_fields_with_no_setting(self):
+        self.assertListEqual(get_admin_model_fields('Event'), [])


### PR DESCRIPTION
This complements the SCHEDULER_BASE_CLASSES feature, by allowing fields
added via a base class to be shown in the admin form for that model.

Example - EventBase adds a 'cost' field, and now the field can be shown
in the admin form too.

```
SCHEDULER_BASE_CLASSES = {
    'Event': ['main.models.EventBase']
}

SCHEDULER_ADMIN_FIELDS = {
    'Event': [('cost',)]
}
```