### PR TITLE
Fix Event _event_params method.

### DIFF
--- a/schedule/models/events.py
+++ b/schedule/models/events.py
@@ -354,7 +354,7 @@ class Event(with_metaclass(ModelBase, *get_model_bases('Event'))):
         event_params = {}
 
         if len(rule_params) == 0:
-            event_params['count'] = 0
+            event_params['count'] = None
             return event_params
 
         for param in rule_params:


### PR DESCRIPTION
There's an issue with dateutil >=2.6.1. They have fixed an issue with count = 0 in this commit
https://github.com/dateutil/dateutil/commit/6192bca0b9f3bed765a2a23c9eb7569043abfa66
It causes return of a wrong rrule object in Event.get_rrule_object method.