### PR TITLE
Fix compatibility with dateutil 2.6.1

### DIFF
--- a/schedule/models/events.py
+++ b/schedule/models/events.py
@@ -354,7 +354,6 @@ class Event(with_metaclass(ModelBase, *get_model_bases('Event'))):
         event_params = {}
 
         if len(rule_params) == 0:
-            event_params['count'] = 0
             return event_params
 
         for param in rule_params:


### PR DESCRIPTION
In recent versions of dateutil, passing a count of 0 to `rrule` means yielding 0 occurrences. Should be left as `None` instead.

The note in dateutil reads:

> Fixed issue where the COUNT parameter of rrules was ignored if 0

See upstream issue and change:

https://github.com/dateutil/dateutil/issues/329
https://github.com/dateutil/dateutil/pull/330

Fixes recent TravisCI failures.