### PR TITLE
change datetime.max to datetime.datetime.max and add empty = False

### DIFF
--- a/schedule/models/events.py
+++ b/schedule/models/events.py
@@ -376,6 +376,7 @@ class Event(with_metaclass(ModelBase, *get_model_bases('Event'))):
     def event_params(self):
         event_params = self._event_params()
         start = self.effective_start
+        empty = False
         if not start:
             empty = True
         elif self.end_recurring_period and start > self.end_recurring_period:
@@ -407,7 +408,7 @@ class Event(with_metaclass(ModelBase, *get_model_bases('Event'))):
                     pass
                 return occ.end
         elif self.pk:
-            return datetime.max
+            return datetime.datetime.max
         return None
 
 


### PR DESCRIPTION
Fixes:

1. `empty` can be referenced before assignment if it is not set to `True`. Changed it to be `False` by default which I assume is the expected behaviour
2. `import datetime` is used instead of `from datetime import datetime`. Therefore, `datetime.datetime.max` has to be used