### PR TITLE
Fix flake8 warning in schedule/apps.py

### DIFF
--- a/schedule/apps.py
+++ b/schedule/apps.py
@@ -6,5 +6,4 @@ from django.utils.translation import ugettext_lazy as _
 
 class ScheduleConfig(AppConfig):
     name = 'schedule'
-    
     verbose_name = _('Schedules')


### PR DESCRIPTION
Appeared as: "W293 blank line contains whitespace".