### PR TITLE
Return start/end times for persistent occurrences with same timezone

### DIFF
--- a/schedule/models/events.py
+++ b/schedule/models/events.py
@@ -161,6 +161,15 @@ class Event(with_metaclass(ModelBase, *get_model_bases('Event'))):
             persisted_occurrences = self.occurrence_set.select_related(None).all()
         else:
             persisted_occurrences = self.occurrence_set.all()
+        tzinfo = timezone.utc
+        if start.tzinfo:
+            tzinfo = start.tzinfo
+        for p in persisted_occurrences:
+            p.start = timezone.localtime(p.start)
+            p.end = timezone.localtime(p.end)
+            if timezone.is_naive(start):
+                p.start = timezone.make_naive(p.start, tzinfo)
+                p.end = timezone.make_naive(p.end, tzinfo)
         occ_replacer = OccurrenceReplacer(persisted_occurrences)
         occurrences = self._get_occurrence_list(start, end)
         final_occurrences = []


### PR DESCRIPTION
as non-persistent occurrences.

When using a timezone that is not UTC, if an occurrence has it's start time modified (and persisted to the DB), the object returned by `get_occurrences()` will not have the expected timezone. 

Instead it is returned as whatever it's stored as in the DB (usually UTC). This results in the list of occurrences being returned being a mix of persistent occurrences in UTC, and non-persistent occurrences using whatever `TIME_ZONE` is set to.

Changed this is set the timezone for persisted occurrences to use the `localtime`.