### PR TITLE
Include license file in the generated wheel package

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,6 +5,9 @@ universal = 1
 exclude = docs
 ignore = E501
 
+[metadata]
+license_file = LICENSE.txt
+
 [isort]
 default_section = THIRDPARTY
 include_trailing_comma = true


### PR DESCRIPTION
The wheel package format supports including the license file. This is done using the `[metadata]` section in the `setup.cfg` file. For additional information on this feature, see:

https://wheel.readthedocs.io/en/stable/index.html#including-the-license-in-the-generated-wheel-file