### PR TITLE
Remove unused Calendar objects from tests

### DIFF
--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -11,10 +11,6 @@ from schedule.models import Calendar, Event, EventRelation, Rule
 
 
 class TestEvent(TestCase):
-
-    def setUp(self):
-        Calendar.objects.create(name="MyCal")
-
     def __create_event(self, title, start, end, cal):
         return Event.objects.create(
             title=title,

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -75,7 +75,6 @@ class TestTemplateTags(TestCase):
         self.assertEqual(query_string['create_event_url'], escape(expected))
 
     def test_all_day_event_cook_slots(self):
-        Calendar.objects.create(name='MyCal', slug='MyCalSlug')
         start = datetime.datetime(
             datetime.datetime.now().year, 1, 5, 0, 0, tzinfo=pytz.utc)
         end = datetime.datetime(


### PR DESCRIPTION
The created calendar objects are unused. In one case, the test's `self.cal` is used instead. In the other, the value is completely unused.