### PR TITLE
Make Calendar.slug field unique

### DIFF
--- a/schedule/migrations/0008_calendar_slug_unique.py
+++ b/schedule/migrations/0008_calendar_slug_unique.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('schedule', '0007_merge_text_fields'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='calendar',
+            name='slug',
+            field=models.SlugField(verbose_name='slug', max_length=200, unique=True),
+        ),
+    ]

--- a/schedule/models/calendars.py
+++ b/schedule/models/calendars.py
@@ -142,7 +142,7 @@ class Calendar(with_metaclass(ModelBase, *get_model_bases('Calendar'))):
     '''
 
     name = models.CharField(_("name"), max_length=200)
-    slug = models.SlugField(_("slug"), max_length=200)
+    slug = models.SlugField(_("slug"), max_length=200, unique=True)
     objects = CalendarManager()
 
     class Meta(object):

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -13,10 +13,9 @@ class TestCalendarInheritance(TestCase):
             class Meta:
                 proxy = True
 
-        base_object = Calendar.objects.create()
-
+        rule = Rule.objects.create()
         self.assertIsInstance(
-            ProxyCalendar.objects.get_or_create_calendar_for_object(base_object),
+            ProxyCalendar.objects.get_or_create_calendar_for_object(rule),
             ProxyCalendar
         )
 
@@ -78,8 +77,8 @@ class TestCalendar(TestCase):
             Calendar.objects.get_calendar_for_object(rule)
 
     def test_get_calendar_for_object_with_more_than_one_calendar(self):
-        calendar_1 = Calendar.objects.create(name='My Cal 1')
-        calendar_2 = Calendar.objects.create(name='My Cal 2')
+        calendar_1 = Calendar.objects.create(name='My Cal 1', slug='my-cal-1')
+        calendar_2 = Calendar.objects.create(name='My Cal 2', slug='my-cal-2')
         rule = Rule.objects.create()
         calendar_1.create_relation(rule)
         calendar_2.create_relation(rule)

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -11,10 +11,6 @@ from schedule.models import Calendar, Event, EventRelation, Rule
 
 
 class TestEvent(TestCase):
-
-    def setUp(self):
-        Calendar.objects.create(name="MyCal")
-
     def __create_event(self, title, start, end, cal):
         return Event.objects.create(
             title=title,

--- a/tests/test_occurrence.py
+++ b/tests/test_occurrence.py
@@ -80,7 +80,7 @@ class TestOccurrence(TestCase):
 
     def test_get_occurrences_non_intersection_returns_empty_occ(self):
         rule = Rule.objects.create(frequency="DAILY")
-        cal = Calendar.objects.create(name="MyCal")
+        cal = Calendar.objects.create(name="MyCal", slug='mycal')
         recurring_event = Event.objects.create(
             title='Recent Event',
             start=datetime.datetime(2016, 1, 5, 8, 0, tzinfo=pytz.utc),
@@ -94,7 +94,7 @@ class TestOccurrence(TestCase):
 
     def test_get_occurrences_is_sorted(self):
         rule = Rule.objects.create(frequency="DAILY")
-        cal = Calendar.objects.create(name="MyCal")
+        cal = Calendar.objects.create(name="MyCal", slug='mycal')
         recurring_event = Event.objects.create(
             title='Recent Event',
             start=datetime.datetime(2016, 1, 5, 8, 0, tzinfo=pytz.utc),

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -74,7 +74,6 @@ class TestTemplateTags(TestCase):
         self.assertEqual(query_string['create_event_url'], escape(expected))
 
     def test_all_day_event_cook_slots(self):
-        Calendar.objects.create(name='MyCal', slug='MyCalSlug')
         start = datetime.datetime(
             datetime.datetime.now().year, 1, 5, 0, 0, tzinfo=pytz.utc)
         end = datetime.datetime(


### PR DESCRIPTION
As the calendar slug is used in URLs to query a single calendar, it should be unique to avoid ambiguous URLs and queries. To avoid the ambiguities, make the `Calendar.slug` field unique.

Fixes #270
  