### PR TITLE
Simplify test object creation using keyword arguments

### DIFF
--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -23,12 +23,11 @@ class TestCalendarInheritance(TestCase):
 
 class TestCalendar(TestCase):
     def __create_event(self, start, end):
-        data = {
-            'title': 'Recent Event',
-            'start': start,
-            'end': end
-        }
-        return Event.objects.create(**data)
+        return Event.objects.create(
+            title='Recent Event',
+            start=start,
+            end=end,
+        )
 
     def test_get_recent_events_without_events_is_empty(self):
         calendar = Calendar()

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -35,20 +35,18 @@ class TestEvent(TestCase):
 
     def test_edge_case_events(self):
         cal = Calendar.objects.create(name="MyCal")
-        data_1 = {
-            'title': 'Edge case event test one',
-            'start': datetime.datetime(2013, 1, 5, 8, 0, tzinfo=pytz.utc),
-            'end': datetime.datetime(2013, 1, 5, 9, 0, tzinfo=pytz.utc),
-            'calendar': cal
-        }
-        data_2 = {
-            'title': 'Edge case event test two',
-            'start': datetime.datetime(2013, 1, 5, 9, 0, tzinfo=pytz.utc),
-            'end': datetime.datetime(2013, 1, 5, 12, 0, tzinfo=pytz.utc),
-            'calendar': cal
-        }
-        event_one = Event.objects.create(**data_1)
-        event_two = Event.objects.create(**data_2)
+        event_one = Event.objects.create(
+            title='Edge case event test one',
+            start=datetime.datetime(2013, 1, 5, 8, 0, tzinfo=pytz.utc),
+            end=datetime.datetime(2013, 1, 5, 9, 0, tzinfo=pytz.utc),
+            calendar=cal,
+        )
+        event_two = Event.objects.create(
+            title='Edge case event test two',
+            start=datetime.datetime(2013, 1, 5, 9, 0, tzinfo=pytz.utc),
+            end=datetime.datetime(2013, 1, 5, 12, 0, tzinfo=pytz.utc),
+            calendar=cal,
+        )
         occurrences_two = event_two.get_occurrences(datetime.datetime(2013, 1, 5, 9, 0, tzinfo=pytz.utc),
                                                     datetime.datetime(2013, 1, 5, 12, 0, tzinfo=pytz.utc))
         self.assertEqual(1, len(occurrences_two))

--- a/tests/test_occurrence.py
+++ b/tests/test_occurrence.py
@@ -88,30 +88,28 @@ class TestOccurrence(TestCase):
     def test_get_occurrences_non_intersection_returns_empty_occ(self):
         rule = Rule.objects.create(frequency="DAILY")
         cal = Calendar.objects.create(name="MyCal")
-        recurring_data = {
-            'title': 'Recent Event',
-            'start': datetime.datetime(2016, 1, 5, 8, 0, tzinfo=pytz.utc),
-            'end': datetime.datetime(2016, 1, 5, 9, 0, tzinfo=pytz.utc),
-            'end_recurring_period': datetime.datetime(2016, 8, 5, 0, 0, tzinfo=pytz.utc),
-            'rule': rule,
-            'calendar': cal
-        }
-        recurring_event = Event.objects.create(**recurring_data)
+        recurring_event = Event.objects.create(
+            title='Recent Event',
+            start=datetime.datetime(2016, 1, 5, 8, 0, tzinfo=pytz.utc),
+            end=datetime.datetime(2016, 1, 5, 9, 0, tzinfo=pytz.utc),
+            end_recurring_period=datetime.datetime(2016, 8, 5, 0, 0, tzinfo=pytz.utc),
+            rule=rule,
+            calendar=cal,
+        )
         occurrences = recurring_event.get_occurrences(start=self.start, end=self.end)
         self.assertEqual(occurrences, [])
 
     def test_get_occurrences_is_sorted(self):
         rule = Rule.objects.create(frequency="DAILY")
         cal = Calendar.objects.create(name="MyCal")
-        recurring_data = {
-            'title': 'Recent Event',
-            'start': datetime.datetime(2016, 1, 5, 8, 0, tzinfo=pytz.utc),
-            'end': datetime.datetime(2016, 1, 5, 9, 0, tzinfo=pytz.utc),
-            'end_recurring_period': datetime.datetime(2016, 8, 5, 0, 0, tzinfo=pytz.utc),
-            'rule': rule,
-            'calendar': cal
-        }
-        recurring_event = Event.objects.create(**recurring_data)
+        recurring_event = Event.objects.create(
+            title='Recent Event',
+            start=datetime.datetime(2016, 1, 5, 8, 0, tzinfo=pytz.utc),
+            end=datetime.datetime(2016, 1, 5, 9, 0, tzinfo=pytz.utc),
+            end_recurring_period=datetime.datetime(2016, 8, 5, 0, 0, tzinfo=pytz.utc),
+            rule=rule,
+            calendar=cal,
+        )
 
         start = datetime.datetime(2016, 1, 12, 0, 0, tzinfo=pytz.utc)
         end = datetime.datetime(2016, 1, 27, 0, 0, tzinfo=pytz.utc)

--- a/tests/test_periods.py
+++ b/tests/test_periods.py
@@ -14,15 +14,14 @@ class TestPeriod(TestCase):
     def setUp(self):
         rule = Rule.objects.create(frequency="WEEKLY")
         cal = Calendar.objects.create(name="MyCal")
-        data = {
-            'title': 'Recent Event',
-            'start': datetime.datetime(2008, 1, 5, 8, 0, tzinfo=pytz.utc),
-            'end': datetime.datetime(2008, 1, 5, 9, 0, tzinfo=pytz.utc),
-            'end_recurring_period': datetime.datetime(2008, 5, 5, 0, 0, tzinfo=pytz.utc),
-            'rule': rule,
-            'calendar': cal,
-        }
-        Event.objects.create(**data)
+        Event.objects.create(
+            title='Recent Event',
+            start=datetime.datetime(2008, 1, 5, 8, 0, tzinfo=pytz.utc),
+            end=datetime.datetime(2008, 1, 5, 9, 0, tzinfo=pytz.utc),
+            end_recurring_period=datetime.datetime(2008, 5, 5, 0, 0, tzinfo=pytz.utc),
+            rule=rule,
+            calendar=cal,
+        )
         self.period = Period(
             events=Event.objects.all(),
             start=datetime.datetime(2008, 1, 4, 7, 0, tzinfo=pytz.utc),
@@ -99,15 +98,14 @@ class TestMonth(TestCase):
     def setUp(self):
         rule = Rule.objects.create(frequency="WEEKLY")
         cal = Calendar.objects.create(name="MyCal")
-        data = {
-            'title': 'Recent Event',
-            'start': datetime.datetime(2008, 1, 5, 8, 0, tzinfo=pytz.utc),
-            'end': datetime.datetime(2008, 1, 5, 9, 0, tzinfo=pytz.utc),
-            'end_recurring_period': datetime.datetime(2008, 5, 5, 0, 0, tzinfo=pytz.utc),
-            'rule': rule,
-            'calendar': cal
-        }
-        Event.objects.create(**data)
+        Event.objects.create(
+            title='Recent Event',
+            start=datetime.datetime(2008, 1, 5, 8, 0, tzinfo=pytz.utc),
+            end=datetime.datetime(2008, 1, 5, 9, 0, tzinfo=pytz.utc),
+            end_recurring_period=datetime.datetime(2008, 5, 5, 0, 0, tzinfo=pytz.utc),
+            rule=rule,
+            calendar=cal,
+        )
         self.month = Month(events=Event.objects.all(),
                            date=datetime.datetime(2008, 2, 7, 9, 0, tzinfo=pytz.utc))
 
@@ -279,15 +277,14 @@ class TestOccurrencePool(TestCase):
     def setUp(self):
         rule = Rule.objects.create(frequency="WEEKLY")
         cal = Calendar.objects.create(name="MyCal")
-        data = {
-            'title': 'Recent Event',
-            'start': datetime.datetime(2008, 1, 5, 8, 0, tzinfo=pytz.utc),
-            'end': datetime.datetime(2008, 1, 5, 9, 0, tzinfo=pytz.utc),
-            'end_recurring_period': datetime.datetime(2008, 5, 5, 0, 0, tzinfo=pytz.utc),
-            'rule': rule,
-            'calendar': cal
-        }
-        self.recurring_event = Event.objects.create(**data)
+        self.recurring_event = Event.objects.create(
+            title='Recent Event',
+            start=datetime.datetime(2008, 1, 5, 8, 0, tzinfo=pytz.utc),
+            end=datetime.datetime(2008, 1, 5, 9, 0, tzinfo=pytz.utc),
+            end_recurring_period=datetime.datetime(2008, 5, 5, 0, 0, tzinfo=pytz.utc),
+            rule=rule,
+            calendar=cal,
+        )
 
     def testPeriodFromPool(self):
         """
@@ -307,15 +304,14 @@ class TestOccurrencesInTimezone(TestCase):
         self.MVD = pytz.timezone('America/Montevideo')
         cal = Calendar.objects.create(name="MyCal")
         rule = Rule.objects.create(frequency="DAILY", params="byweekday:SA", name="Saturdays")
-        data = {
-            'title': 'Every Saturday Event',
-            'start': self.MVD.localize(datetime.datetime(2017, 1, 7, 22, 0)),
-            'end': self.MVD.localize(datetime.datetime(2017, 1, 7, 23, 0)),
-            'end_recurring_period': self.MVD.localize(datetime.datetime(2017, 2, 1)),
-            'rule': rule,
-            'calendar': cal,
-        }
-        Event.objects.create(**data)
+        Event.objects.create(
+            title='Every Saturday Event',
+            start=self.MVD.localize(datetime.datetime(2017, 1, 7, 22, 0)),
+            end=self.MVD.localize(datetime.datetime(2017, 1, 7, 23, 0)),
+            end_recurring_period=self.MVD.localize(datetime.datetime(2017, 2, 1)),
+            rule=rule,
+            calendar=cal,
+        )
 
     @override_settings(TIME_ZONE='America/Montevideo')
     def test_occurrences_with_TZ(self):
@@ -352,15 +348,14 @@ class TestWeeklyOccurrences(TestCase):
         self.MVD = pytz.timezone('America/Montevideo')  # UTC-3
         cal = Calendar.objects.create(name="MyCal")
         rule = Rule.objects.create(frequency="DAILY", name="daily")
-        data = {
-            'title': 'Test event',
-            'start': self.MVD.localize(datetime.datetime(2017, 1, 13, 15, 0)),
-            'end': self.MVD.localize(datetime.datetime(2017, 1, 14, 15, 0)),
-            'end_recurring_period': self.MVD.localize(datetime.datetime(2017, 1, 20)),
-            'rule': rule,
-            'calendar': cal
-        }
-        Event.objects.create(**data)
+        Event.objects.create(
+            title='Test event',
+            start=self.MVD.localize(datetime.datetime(2017, 1, 13, 15, 0)),
+            end=self.MVD.localize(datetime.datetime(2017, 1, 14, 15, 0)),
+            end_recurring_period=self.MVD.localize(datetime.datetime(2017, 1, 20)),
+            rule=rule,
+            calendar=cal,
+        )
 
     def test_occurrences_inside_recurrence_period(self):
         start = self.MVD.localize(datetime.datetime(2017, 1, 13))

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -26,15 +26,14 @@ class TestTemplateTags(TestCase):
         rule = Rule.objects.create(frequency='WEEKLY')
         self.cal = Calendar.objects.create(name='MyCal', slug='MyCalSlug')
 
-        data = {
-            'title': 'Recent Event',
-            'start': datetime.datetime(datetime.datetime.now().year, 1, 5, 8, 0, tzinfo=pytz.utc),
-            'end': datetime.datetime(datetime.datetime.now().year, 1, 5, 9, 0, tzinfo=pytz.utc),
-            'end_recurring_period': datetime.datetime(datetime.datetime.now().year, 5, 5, 0, 0, tzinfo=pytz.utc),
-            'rule': rule,
-            'calendar': self.cal,
-        }
-        Event.objects.create(**data)
+        Event.objects.create(
+            title='Recent Event',
+            start=datetime.datetime(datetime.datetime.now().year, 1, 5, 8, 0, tzinfo=pytz.utc),
+            end=datetime.datetime(datetime.datetime.now().year, 1, 5, 9, 0, tzinfo=pytz.utc),
+            end_recurring_period=datetime.datetime(datetime.datetime.now().year, 5, 5, 0, 0, tzinfo=pytz.utc),
+            rule=rule,
+            calendar=self.cal,
+        )
         self.period = Period(events=Event.objects.all(),
                              start=datetime.datetime(datetime.datetime.now().year, 1, 4, 7, 0, tzinfo=pytz.utc),
                              end=datetime.datetime(datetime.datetime.now().year, 1, 21, 7, 0, tzinfo=pytz.utc))
@@ -80,13 +79,12 @@ class TestTemplateTags(TestCase):
             datetime.datetime.now().year, 1, 5, 0, 0, tzinfo=pytz.utc)
         end = datetime.datetime(
             datetime.datetime.now().year, 1, 6, 0, 0, tzinfo=pytz.utc)
-        data = {
-            'title': 'All Day Event',
-            'start': start,
-            'end': end,
-            'calendar': self.cal,
-        }
-        event = Event.objects.create(**data)
+        event = Event.objects.create(
+            title='All Day Event',
+            start=start,
+            end=end,
+            calendar=self.cal,
+        )
         period = Day([event], start, end)
 
         slots = _cook_slots(period, 60)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -18,22 +18,22 @@ class TestEventListManager(TestCase):
         cal = Calendar.objects.create(name="MyCal")
         self.default_tzinfo = timezone.get_default_timezone()
 
-        self.event1 = Event.objects.create(**{
-            'title': 'Weekly Event',
-            'start': datetime.datetime(2009, 4, 1, 8, 0, tzinfo=self.default_tzinfo),
-            'end': datetime.datetime(2009, 4, 1, 9, 0, tzinfo=self.default_tzinfo),
-            'end_recurring_period': datetime.datetime(2009, 10, 5, 0, 0, tzinfo=self.default_tzinfo),
-            'rule': weekly,
-            'calendar': cal
-        })
-        self.event2 = Event.objects.create(**{
-            'title': 'Recent Event',
-            'start': datetime.datetime(2008, 1, 5, 9, 0, tzinfo=self.default_tzinfo),
-            'end': datetime.datetime(2008, 1, 5, 10, 0, tzinfo=self.default_tzinfo),
-            'end_recurring_period': datetime.datetime(2009, 5, 5, 0, 0, tzinfo=self.default_tzinfo),
-            'rule': daily,
-            'calendar': cal
-        })
+        self.event1 = Event.objects.create(
+            title='Weekly Event',
+            start=datetime.datetime(2009, 4, 1, 8, 0, tzinfo=self.default_tzinfo),
+            end=datetime.datetime(2009, 4, 1, 9, 0, tzinfo=self.default_tzinfo),
+            end_recurring_period=datetime.datetime(2009, 10, 5, 0, 0, tzinfo=self.default_tzinfo),
+            rule=weekly,
+            calendar=cal,
+        )
+        self.event2 = Event.objects.create(
+            title='Recent Event',
+            start=datetime.datetime(2008, 1, 5, 9, 0, tzinfo=self.default_tzinfo),
+            end=datetime.datetime(2008, 1, 5, 10, 0, tzinfo=self.default_tzinfo),
+            end_recurring_period=datetime.datetime(2009, 5, 5, 0, 0, tzinfo=self.default_tzinfo),
+            rule=daily,
+            calendar=cal,
+        )
 
     def test_occurrences_after(self):
         eml = EventListManager([self.event1, self.event2])
@@ -60,14 +60,14 @@ class TestOccurrenceReplacer(TestCase):
         self.default_tzinfo = timezone.get_default_timezone()
         self.start = timezone.now() - datetime.timedelta(days=10)
         self.end = self.start + datetime.timedelta(days=300)
-        self.event1 = Event.objects.create(**{
-            'title': 'Weekly Event',
-            'start': self.start,
-            'end': self.end,
-            'end_recurring_period': self.end,
-            'rule': weekly,
-            'calendar': cal
-        })
+        self.event1 = Event.objects.create(
+            title='Weekly Event',
+            start=self.start,
+            end=self.end,
+            end_recurring_period=self.end,
+            rule=weekly,
+            calendar=cal,
+        )
         self.occ = Occurrence.objects.create(
             event=self.event1,
             start=self.start,
@@ -75,14 +75,14 @@ class TestOccurrenceReplacer(TestCase):
             original_start=self.start,
             original_end=self.end)
 
-        self.event2 = Event.objects.create(**{
-            'title': 'Recent Event',
-            'start': datetime.datetime(2008, 1, 5, 9, 0, tzinfo=self.default_tzinfo),
-            'end': datetime.datetime(2008, 1, 5, 10, 0, tzinfo=self.default_tzinfo),
-            'end_recurring_period': datetime.datetime(2009, 5, 5, 0, 0, tzinfo=self.default_tzinfo),
-            'rule': daily,
-            'calendar': cal
-        })
+        self.event2 = Event.objects.create(
+            title='Recent Event',
+            start=datetime.datetime(2008, 1, 5, 9, 0, tzinfo=self.default_tzinfo),
+            end=datetime.datetime(2008, 1, 5, 10, 0, tzinfo=self.default_tzinfo),
+            end_recurring_period=datetime.datetime(2009, 5, 5, 0, 0, tzinfo=self.default_tzinfo),
+            rule=daily,
+            calendar=cal,
+        )
 
     def test_has_occurrence(self):
         other_occ = Occurrence.objects.create(

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -22,15 +22,14 @@ class TestViews(TestCase):
     def setUp(self):
         self.rule = Rule.objects.create(frequency="DAILY")
         self.calendar = Calendar.objects.create(name="MyCal", slug='MyCalSlug')
-        data = {
-            'title': 'Recent Event',
-            'start': datetime.datetime(2008, 1, 5, 8, 0, tzinfo=pytz.utc),
-            'end': datetime.datetime(2008, 1, 5, 9, 0, tzinfo=pytz.utc),
-            'end_recurring_period': datetime.datetime(2008, 5, 5, 0, 0, tzinfo=pytz.utc),
-            'rule': self.rule,
-            'calendar': self.calendar
-        }
-        self.event = Event.objects.create(**data)
+        self.event = Event.objects.create(
+            title='Recent Event',
+            start=datetime.datetime(2008, 1, 5, 8, 0, tzinfo=pytz.utc),
+            end=datetime.datetime(2008, 1, 5, 9, 0, tzinfo=pytz.utc),
+            end_recurring_period=datetime.datetime(2008, 5, 5, 0, 0, tzinfo=pytz.utc),
+            rule=self.rule,
+            calendar=self.calendar,
+        )
 
     @override_settings(USE_TZ=False)
     def test_timezone_off(self):
@@ -44,15 +43,14 @@ class TestViewUtils(TestCase):
     def setUp(self):
         self.rule = Rule.objects.create(frequency="DAILY")
         self.calendar = Calendar.objects.create(name="MyCal", slug='MyCalSlug')
-        data = {
-            'title': 'Recent Event',
-            'start': datetime.datetime(2008, 1, 5, 8, 0, tzinfo=pytz.utc),
-            'end': datetime.datetime(2008, 1, 5, 9, 0, tzinfo=pytz.utc),
-            'end_recurring_period': datetime.datetime(2008, 5, 5, 0, 0, tzinfo=pytz.utc),
-            'rule': self.rule,
-            'calendar': self.calendar
-        }
-        self.event = Event.objects.create(**data)
+        self.event = Event.objects.create(
+            title='Recent Event',
+            start=datetime.datetime(2008, 1, 5, 8, 0, tzinfo=pytz.utc),
+            end=datetime.datetime(2008, 1, 5, 9, 0, tzinfo=pytz.utc),
+            end_recurring_period=datetime.datetime(2008, 5, 5, 0, 0, tzinfo=pytz.utc),
+            rule=self.rule,
+            calendar=self.calendar,
+        )
 
     def test_get_occurrence(self):
         event, occurrence = get_occurrence(self.event.pk, year=2008, month=1,
@@ -191,15 +189,14 @@ class TestUrls(TestCase):
         # create a calendar and event
         calendar = Calendar.objects.create(name="MyCal", slug='MyCalSlug')
         rule = Rule.objects.create(frequency="DAILY")
-        data = {
-            'title': 'Recent Event',
-            'start': datetime.datetime(2008, 1, 5, 8, 0, tzinfo=pytz.utc),
-            'end': datetime.datetime(2008, 1, 5, 9, 0, tzinfo=pytz.utc),
-            'end_recurring_period': datetime.datetime(2008, 5, 5, 0, 0, tzinfo=pytz.utc),
-            'rule': rule,
-            'calendar': calendar
-        }
-        Event.objects.create(**data)
+        Event.objects.create(
+            title='Recent Event',
+            start=datetime.datetime(2008, 1, 5, 8, 0, tzinfo=pytz.utc),
+            end=datetime.datetime(2008, 1, 5, 9, 0, tzinfo=pytz.utc),
+            end_recurring_period=datetime.datetime(2008, 5, 5, 0, 0, tzinfo=pytz.utc),
+            rule=rule,
+            calendar=calendar,
+        )
         # test calendar slug
         response = self.client.get(
             reverse("api_occurences") + "?calendar={}&start={}&end={}".format(
@@ -223,15 +220,14 @@ class TestUrls(TestCase):
         # create a calendar and event
         calendar = Calendar.objects.create(name="MyCal", slug='MyCalSlug')
         rule = Rule.objects.create(frequency="DAILY")
-        data = {
-            'title': 'Recent Event',
-            'start': datetime.datetime(2008, 1, 5, 8, 0, tzinfo=pytz.utc),
-            'end': datetime.datetime(2008, 1, 5, 9, 0, tzinfo=pytz.utc),
-            'end_recurring_period': datetime.datetime(2008, 1, 8, 0, 0, tzinfo=pytz.utc),
-            'rule': rule,
-            'calendar': calendar
-        }
-        event = Event.objects.create(**data)
+        event = Event.objects.create(
+            title='Recent Event',
+            start=datetime.datetime(2008, 1, 5, 8, 0, tzinfo=pytz.utc),
+            end=datetime.datetime(2008, 1, 5, 9, 0, tzinfo=pytz.utc),
+            end_recurring_period=datetime.datetime(2008, 1, 8, 0, 0, tzinfo=pytz.utc),
+            rule=rule,
+            calendar=calendar,
+        )
         Occurrence.objects.create(
             event=event,
             title='My persisted Occ',
@@ -264,14 +260,13 @@ class TestUrls(TestCase):
     def test_occurences_api_works_with_and_without_cal_slug(self):
         # create a calendar and event
         calendar = Calendar.objects.create(name="MyCal", slug='MyCalSlug')
-        data = {
-            'title': 'Recent Event',
-            'start': datetime.datetime(2008, 1, 5, 8, 0, tzinfo=pytz.utc),
-            'end': datetime.datetime(2008, 1, 5, 9, 0, tzinfo=pytz.utc),
-            'end_recurring_period': datetime.datetime(2008, 5, 5, 0, 0, tzinfo=pytz.utc),
-            'calendar': calendar
-        }
-        event = Event.objects.create(**data)
+        event = Event.objects.create(
+            title='Recent Event',
+            start=datetime.datetime(2008, 1, 5, 8, 0, tzinfo=pytz.utc),
+            end=datetime.datetime(2008, 1, 5, 9, 0, tzinfo=pytz.utc),
+            end_recurring_period=datetime.datetime(2008, 5, 5, 0, 0, tzinfo=pytz.utc),
+            calendar=calendar,
+        )
         # test calendar slug
         response = self.client.get(
             reverse('api_occurences'),
@@ -291,22 +286,20 @@ class TestUrls(TestCase):
     def test_cal_slug_filters_returned_events(self):
         calendar1 = Calendar.objects.create(name="MyCal1", slug='MyCalSlug1')
         calendar2 = Calendar.objects.create(name="MyCal2", slug='MyCalSlug2')
-        data1 = {
-            'title': 'Recent Event 1',
-            'start': datetime.datetime(2008, 1, 5, 8, 0, tzinfo=pytz.utc),
-            'end': datetime.datetime(2008, 1, 5, 9, 0, tzinfo=pytz.utc),
-            'end_recurring_period': datetime.datetime(2008, 5, 5, 0, 0, tzinfo=pytz.utc),
-            'calendar': calendar1
-        }
-        data2 = {
-            'title': 'Recent Event 2',
-            'start': datetime.datetime(2008, 1, 5, 8, 0, tzinfo=pytz.utc),
-            'end': datetime.datetime(2008, 1, 5, 9, 0, tzinfo=pytz.utc),
-            'end_recurring_period': datetime.datetime(2008, 5, 5, 0, 0, tzinfo=pytz.utc),
-            'calendar': calendar2
-        }
-        event1 = Event.objects.create(**data1)
-        event2 = Event.objects.create(**data2)
+        event1 = Event.objects.create(
+            title='Recent Event 1',
+            start=datetime.datetime(2008, 1, 5, 8, 0, tzinfo=pytz.utc),
+            end=datetime.datetime(2008, 1, 5, 9, 0, tzinfo=pytz.utc),
+            end_recurring_period=datetime.datetime(2008, 5, 5, 0, 0, tzinfo=pytz.utc),
+            calendar=calendar1,
+        )
+        event2 = Event.objects.create(
+            title='Recent Event 2',
+            start=datetime.datetime(2008, 1, 5, 8, 0, tzinfo=pytz.utc),
+            end=datetime.datetime(2008, 1, 5, 9, 0, tzinfo=pytz.utc),
+            end_recurring_period=datetime.datetime(2008, 5, 5, 0, 0, tzinfo=pytz.utc),
+            calendar=calendar2,
+        )
         # Test both present with no cal arg
         response = self.client.get(reverse("api_occurences"),
                                    {'start': '2008-01-05',


### PR DESCRIPTION
Instead of first creating a dict followed by the `**` operator, simply
pass the keyword arguments directly to `Model.objects.create()`.