### PR TITLE
Convert the text NULL data to the empty string before schema changes

### DIFF
--- a/schedule/migrations/0006_update_text_fields_empty_string.py
+++ b/schedule/migrations/0006_update_text_fields_empty_string.py
@@ -1,0 +1,40 @@
+from django.db import migrations
+
+
+def forwards(apps, schema_editor):
+    model_fields = [
+        ('CalendarRelation', ['distinction']),
+        ('Event', ['color_event', 'description']),
+        ('EventRelation', ['distinction']),
+        ('Occurrence', ['description', 'title']),
+        ('Rule', ['params']),
+    ]
+    for model_name, fields in model_fields:
+        model_class = apps.get_model('schedule', model_name)
+        for field_name in fields:
+            model_class.objects.filter(**{field_name: None}).update(**{field_name: ''})
+
+
+def reverse(apps, schema_editor):
+    model_fields = [
+        ('CalendarRelation', ['distinction']),
+        ('Event', ['color_event', 'description']),
+        ('EventRelation', ['distinction']),
+        ('Occurrence', ['description', 'title']),
+        ('Rule', ['params']),
+    ]
+    for model_name, fields in model_fields:
+        model_class = apps.get_model('schedule', model_name)
+        for field_name in fields:
+            model_class.objects.filter(**{field_name: ''}).update(**{field_name: None})
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('schedule', '0003_auto_20160715_0028'),
+    ]
+
+    operations = [
+        migrations.RunPython(forwards, reverse, elidable=True),
+    ]

--- a/schedule/migrations/0007_merge_text_fields.py
+++ b/schedule/migrations/0007_merge_text_fields.py
@@ -1,0 +1,12 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('schedule', '0006_update_text_fields_empty_string'),
+        ('schedule', '0005_verbose_name_plural_for_calendar'),
+    ]
+
+    operations = [
+    ]


### PR DESCRIPTION
Handling schema changes and data changes should be handled in separate transactions to avoid pending trigger events.

Fixes the error:

```
django.db.utils.OperationalError: cannot ALTER TABLE "schedule_event" because it has pending trigger events
```

From:

https://docs.djangoproject.com/en/2.0/topics/migrations/#data-migrations

> Migrations that alter data are usually called “data migrations”; they’re best written as separate migrations, sitting alongside your schema migrations.

The previous data migration was implied by the alter operation.

Fixes #361