### PR TITLE
Remove link to non-existent CSS file

### DIFF
--- a/schedule/templates/fullcalendar.html
+++ b/schedule/templates/fullcalendar.html
@@ -5,7 +5,6 @@
 {% block head_title %}Calendar: {{ object.name }}{% endblock %}
 {% block tab_id %}id='home_tab'{% endblock %}
 {% block extra_head %}
-	<link rel="stylesheet" href="{% static 'schedule/css/modal.css' %}" />
     {% include "fullcalendar_script.html" %}
 {% endblock %}
 


### PR DESCRIPTION
The static file schedule/css/modal.css does not exist.

Fixes #221  
Fixes #242
  