### PR TITLE
Update and improve project links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 Django Scheduler
 ========
 
-[![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/llazzaro/django-scheduler?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/llazzaro/django-scheduler)
 [<img src="https://img.shields.io/travis/llazzaro/django-scheduler.svg">](https://travis-ci.org/llazzaro/django-scheduler)
 [![Code Health](https://landscape.io/github/llazzaro/django-scheduler/master/landscape.svg?style=flat)](https://landscape.io/github/llazzaro/django-scheduler/master)
 [<img src="https://img.shields.io/coveralls/llazzaro/django-scheduler.svg">](https://coveralls.io/r/llazzaro/django-scheduler)
 [<img src="https://img.shields.io/pypi/v/django-scheduler.svg">](https://pypi.python.org/pypi/django-scheduler)
 [<img src="https://pypip.in/d/django-scheduler/badge.png">](https://pypi.python.org/pypi/django-scheduler)
 [<img src="https://pypip.in/license/django-scheduler/badge.png">](https://github.com/llazzaro/django-scheduler/blob/master/LICENSE.txt)
-[![Documentation Status](http://readthedocs.org/projects/django-scheduler/badge/?version=latest)](http://django-scheduler.readthedocs.org/en/latest/?badge=latest)
+[![Documentation Status](https://readthedocs.org/projects/django-scheduler/badge/)](https://django-scheduler.readthedocs.io/)
 
 
 A calendar app for Django
@@ -22,7 +22,7 @@ Donate bitcoins to this project.
 Information
 ========
 
-* [Documentation](http://django-scheduler.readthedocs.org/en/latest/)
+* [Documentation](https://django-scheduler.readthedocs.io/)
 * [Wiki](https://github.com/llazzaro/django-scheduler/wiki)
 * [Sample Project](https://github.com/llazzaro/django-scheduler-sample)
 

--- a/schedule/models/rules.py
+++ b/schedule/models/rules.py
@@ -39,7 +39,7 @@ class Rule(with_metaclass(ModelBase, *get_model_bases('Rule'))):
         value = int[,int]*
 
       The options are: (documentation for these can be found at
-      http://labix.org/python-dateutil#head-470fa22b2db72000d7abe698a5783a46b0731b57)
+      https://dateutil.readthedocs.io/en/stable/rrule.html#module-dateutil.rrule
         ** count
         ** bysetpos
         ** bymonth

--- a/schedule/widgets.py
+++ b/schedule/widgets.py
@@ -6,7 +6,7 @@ from django.utils.safestring import mark_safe
 
 class SpectrumColorPicker(TextInput):
     """
-    Based on Brian Grinstead's Spectrum - http://bgrins.github.com/spectrum/
+    Based on Brian Grinstead's Spectrum - https://bgrins.github.io/spectrum/
     """
     class Media:
         css = {'all': ("//cdnjs.cloudflare.com/ajax/libs/spectrum/1.7.1/spectrum.css",)}

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -71,7 +71,6 @@ PASSWORD_HASHERS = [
 ]
 
 # URL prefix for static files.
-# Example: "http://example.com/static/", "http://static.example.com/"
 STATIC_URL = '/static/'
 
 STATICFILES_FINDERS = (


### PR DESCRIPTION
- Prefer https over http
- Drop unnecessary utm_* style "campaign" parameters to improve privacy
- Use updated dateutil documentation
- Drop comment with bogus URL to improve grep
- For the read the docs badge, use the documented URL, https://docs.readthedocs.io/en/latest/badges.html
- Prefer readthedocs.io instead of readthedocs.org for doc links

Read the Docs moved hosting to readthedocs.io instead of readthedocs.org.

For additional details, see:

https://blog.readthedocs.com/securing-subdomains/

> Starting today, Read the Docs will start hosting projects from subdomains on
> the domain readthedocs.io, instead of on readthedocs.org. This change
> addresses some security concerns around site cookies while hosting user
> generated data on the same domain as our dashboard.