### PR TITLE
Index all generic foreign keys to improve query performance

### DIFF
--- a/schedule/migrations/0008_gfk_index.py
+++ b/schedule/migrations/0008_gfk_index.py
@@ -1,0 +1,30 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('contenttypes', '0002_remove_content_type_name'),
+        ('schedule', '0007_merge_text_fields'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='calendarrelation',
+            name='object_id',
+            field=models.IntegerField(db_index=True),
+        ),
+        migrations.AlterField(
+            model_name='eventrelation',
+            name='object_id',
+            field=models.IntegerField(db_index=True),
+        ),
+        migrations.AlterIndexTogether(
+            name='calendarrelation',
+            index_together={('content_type', 'object_id')},
+        ),
+        migrations.AlterIndexTogether(
+            name='eventrelation',
+            index_together={('content_type', 'object_id')},
+        ),
+    ]

--- a/schedule/models/calendars.py
+++ b/schedule/models/calendars.py
@@ -102,7 +102,7 @@ class CalendarManager(models.Manager):
             dist_q = Q(calendarrelation__distinction=distinction)
         else:
             dist_q = Q()
-        return self.filter(dist_q, calendarrelation__object_id=obj.id, calendarrelation__content_type=ct)
+        return self.filter(dist_q, calendarrelation__content_type=ct, calendarrelation__object_id=obj.id)
 
 
 @python_2_unicode_compatible
@@ -226,7 +226,7 @@ class CalendarRelation(with_metaclass(ModelBase, *get_model_bases('CalendarRelat
 
     calendar = models.ForeignKey(Calendar, on_delete=models.CASCADE, verbose_name=_("calendar"))
     content_type = models.ForeignKey(ContentType, on_delete=models.CASCADE)
-    object_id = models.IntegerField()
+    object_id = models.IntegerField(db_index=True)
     content_object = fields.GenericForeignKey('content_type', 'object_id')
     distinction = models.CharField(_("distinction"), max_length=20)
     inheritable = models.BooleanField(_("inheritable"), default=True)
@@ -237,6 +237,7 @@ class CalendarRelation(with_metaclass(ModelBase, *get_model_bases('CalendarRelat
         verbose_name = _('calendar relation')
         verbose_name_plural = _('calendar relations')
         app_label = 'schedule'
+        index_together = [('content_type', 'object_id')]
 
     def __str__(self):
         return '%s - %s' % (self.calendar, self.content_object)

--- a/schedule/models/events.py
+++ b/schedule/models/events.py
@@ -506,13 +506,13 @@ class EventRelationManager(models.Manager):
         if inherit:
             inherit_q = Q(
                 cal_dist_q,
-                calendar__calendarrelation__object_id=content_object.id,
                 calendar__calendarrelation__content_type=ct,
+                calendar__calendarrelation__object_id=content_object.id,
                 calendar__calendarrelation__inheritable=True,
             )
         else:
             inherit_q = Q()
-        event_q = Q(dist_q, eventrelation__object_id=content_object.id, eventrelation__content_type=ct)
+        event_q = Q(dist_q, eventrelation__content_type=ct, eventrelation__object_id=content_object.id)
         return Event.objects.filter(inherit_q | event_q)
 
     def create_relation(self, event, content_object, distinction=''):
@@ -547,7 +547,7 @@ class EventRelation(with_metaclass(ModelBase, *get_model_bases('EventRelation'))
     '''
     event = models.ForeignKey(Event, on_delete=models.CASCADE, verbose_name=_("event"))
     content_type = models.ForeignKey(ContentType, on_delete=models.CASCADE)
-    object_id = models.IntegerField()
+    object_id = models.IntegerField(db_index=True)
     content_object = fields.GenericForeignKey('content_type', 'object_id')
     distinction = models.CharField(_("distinction"), max_length=20)
 
@@ -557,6 +557,7 @@ class EventRelation(with_metaclass(ModelBase, *get_model_bases('EventRelation'))
         verbose_name = _("event relation")
         verbose_name_plural = _("event relations")
         app_label = 'schedule'
+        index_together = [('content_type', 'object_id')]
 
     def __str__(self):
         return '%s(%s)-%s' % (self.event.title, self.distinction, self.content_object)


### PR DESCRIPTION
It is generally recommended that relationship fields should be indexed.
It is considered a misfeature that Django's GFKs do not created indexes
by default. For example, see the discussion at:

https://code.djangoproject.com/ticket/23435

To avoid this performance pitfall, add the necessary indexes.