### PR TITLE
Fix Django version in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 coverage>=3.7.1
 coveralls>=0.5
-Django>=2.0
+Django>=1.11
 flake8
 icalendar>=3.8.4
 isort

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
         'Topic :: Utilities',
     ],
     install_requires=[
-        'Django>=2.0',
+        'Django>=1.11',
         'python-dateutil>=2.1',
         'pytz>=2013.9',
         'icalendar>=3.8.4',


### PR DESCRIPTION
django-scheduler works with both Django 1.11 & 2.0.