### PR TITLE
Remove unnecessary app_label form model's Meta

### DIFF
--- a/schedule/models/calendars.py
+++ b/schedule/models/calendars.py
@@ -146,7 +146,6 @@ class Calendar(models.Model):
     class Meta(object):
         verbose_name = _('calendar')
         verbose_name_plural = _('calendars')
-        app_label = 'schedule'
 
     def __str__(self):
         return self.name
@@ -234,7 +233,6 @@ class CalendarRelation(models.Model):
     class Meta(object):
         verbose_name = _('calendar relation')
         verbose_name_plural = _('calendar relations')
-        app_label = 'schedule'
         index_together = [('content_type', 'object_id')]
 
     def __str__(self):

--- a/schedule/models/events.py
+++ b/schedule/models/events.py
@@ -86,7 +86,6 @@ class Event(models.Model):
     class Meta(object):
         verbose_name = _('event')
         verbose_name_plural = _('events')
-        app_label = 'schedule'
         index_together = (
             ('start', 'end'),
         )
@@ -554,7 +553,6 @@ class EventRelation(models.Model):
     class Meta(object):
         verbose_name = _("event relation")
         verbose_name_plural = _("event relations")
-        app_label = 'schedule'
         index_together = [('content_type', 'object_id')]
 
     def __str__(self):
@@ -577,7 +575,6 @@ class Occurrence(models.Model):
     class Meta(object):
         verbose_name = _("occurrence")
         verbose_name_plural = _("occurrences")
-        app_label = 'schedule'
         index_together = (
             ('start', 'end'),
         )

--- a/schedule/models/rules.py
+++ b/schedule/models/rules.py
@@ -64,7 +64,6 @@ class Rule(models.Model):
     class Meta(object):
         verbose_name = _('rule')
         verbose_name_plural = _('rules')
-        app_label = 'schedule'
 
     def rrule_frequency(self):
         compatibility_dict = {


### PR DESCRIPTION
Django already calculates the app_label, it isn't required to respecify
it. Removing it reduces noise in the model definition.