### PR TITLE
In migration, only create the default Calendar if events need it

### DIFF
--- a/schedule/migrations/0010_events_set_missing_calendar.py
+++ b/schedule/migrations/0010_events_set_missing_calendar.py
@@ -4,10 +4,13 @@ from django.db import migrations
 def forwards(apps, schema_editor):
     Calendar = apps.get_model('schedule', 'Calendar')
     Event = apps.get_model('schedule', 'Event')
-    calendar, _created = Calendar.objects.get_or_create(
-        name='default',
-        defaults={'slug': 'default'})
-    Event.objects.filter(calendar=None).update(calendar=calendar)
+    events_qs = Event.objects.filter(calendar=None)
+    # Only create the default Calendar object if events need it.
+    if events_qs.exists():
+        calendar, _created = Calendar.objects.get_or_create(
+            name='default',
+            defaults={'slug': 'default'})
+        events_qs.update(calendar=calendar)
 
 
 class Migration(migrations.Migration):


### PR DESCRIPTION
Noticed after integrating django-scheduler develop into a project.

Avoids needlessly creating an unused Calendar object. Can be surprising to projects that don't expect it to be created.