### PR TITLE
Trim trialing white space throughout the project

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,10 +1,10 @@
 Copyright (c) 2008-2017, Tony Hauber
 All rights reserved.
- 
+
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are
 met:
- 
+
     * Redistributions of source code must retain the above copyright
       notice, this list of conditions and the following disclaimer.
     * Redistributions in binary form must reproduce the above
@@ -14,7 +14,7 @@ met:
     * Neither the name of the author nor the names of other
       contributors may be used to endorse or promote products derived
       from this software without specific prior written permission.
- 
+
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR

--- a/docs/index.txt
+++ b/docs/index.txt
@@ -3,7 +3,7 @@
 Welcome to DjangoSchedule's documentation!
 ==========================================
 
-DjangoSchedule is an open-source calendaring application. 
+DjangoSchedule is an open-source calendaring application.
 
 .. toctree::
     :maxdepth: 1
@@ -24,4 +24,3 @@ Indices and tables
 * :ref:`genindex`
 * :ref:`modindex`
 * :ref:`search`
-

--- a/docs/overview.txt
+++ b/docs/overview.txt
@@ -5,7 +5,7 @@ A Quick Overview
 What is an Event?
 -----------------
 
-An event doesn't have any date or time associated with it, just a rule for how it recurs. In a way it designates a set of occurrences.  A weekly staff meeting is a perfect example.  A weekly staff meeting is an event, it says what it is and how often it recurs.  Now if we were to say Tuesday's staff meeting, that's an occurrence. That is, a specific element in the set of occurrences designated by weekly staff meeting.  
+An event doesn't have any date or time associated with it, just a rule for how it recurs. In a way it designates a set of occurrences.  A weekly staff meeting is a perfect example.  A weekly staff meeting is an event, it says what it is and how often it recurs.  Now if we were to say Tuesday's staff meeting, that's an occurrence. That is, a specific element in the set of occurrences designated by weekly staff meeting.
 
 There is an exception, and that is the "one-time" event. If your boss calls and sets up a meeting today at 3. That's a one-time event. It's only going to happen this one time. That doesn't mean it's an occurrence. It just means that it's an event which represents a set of occurrences that only has one occurrence in it.
 

--- a/docs/periods.txt
+++ b/docs/periods.txt
@@ -72,7 +72,7 @@ This method returns whether there are any occurrences in this period
 Year
 ----
 
-The year period is instantiated with a list of events and a date or datetime object. It will resemble the year in which that date exists. 
+The year period is instantiated with a list of events and a date or datetime object. It will resemble the year in which that date exists.
 
 >>> p = Year(events, datetime.datetime(2008,4,1))
 >>> p.start

--- a/docs/template_tags.txt
+++ b/docs/template_tags.txt
@@ -30,6 +30,3 @@ This is useful when creating links as the calendar_by_period view uses this to d
 >>> # Now everything except the seconds
 >>> querystring_for_date(date, num=5)
 '?year=2009&month=4&day=1&hour=0&minute=0'
-
-
-    

--- a/docs/views.txt
+++ b/docs/views.txt
@@ -55,15 +55,15 @@ Optional Arguments
 ``template_name``
     default
         'schedule/calendar_by_period.html'
-    
+
     This is the template that will be rendered.
 
 ``periods``
     default
         ``[]``
-    
+
     This is a list of Period Subclasses that designates which periods you would like to instantiate and put in the context.
-    
+
 Context Variables
 -----------------
 
@@ -74,9 +74,9 @@ Context Variables
     this is a dictionary that returns the periods from the list you passed
     in.  If you passed in Month and Day, then your dictionary would look
     like this
-    
+
     ::
-    
+
         {
             'month': <schedule.periods.Month object>
             'day':   <schedule.periods.Day object>
@@ -95,9 +95,9 @@ Context Variables
 event
 =====
 
-This view is for showing an event. It is important to remember that an 
+This view is for showing an event. It is important to remember that an
 event is not an occurrence.  Events define a set of recurring occurrences.
-If you would like to display an occurrence (a single instance of a 
+If you would like to display an occurrence (a single instance of a
 recurring event) use ``occurrence``.
 
 Required Arguments
@@ -115,7 +115,7 @@ Optional Arguments
 ``template_name``
     default
         'schedule/calendar_by_period.html'
-    
+
     This is the template that will be rendered.
 
 
@@ -133,7 +133,7 @@ occurrence
 ==========
 
 This view is used to display an occurrence.  There are two methods of
-displaying an occurrence.  
+displaying an occurrence.
 
 Required Arguments
 ------------------
@@ -164,7 +164,7 @@ Optional Arguments
 ``template_name``
     default
         'schedule/calendar_by_period.html'
-    
+
     This is the template that will be rendered
 
 
@@ -175,7 +175,7 @@ Context Variables
 ``event``
     the event that produces the occurrence
 
-``occurrence`` 
+``occurrence``
     the occurrence to be displayed
 
 ``back_url``
@@ -215,7 +215,7 @@ Optional Arguments
 ``template_name``
     default
         'schedule/calendar_by_period.html'
-    
+
     This is the template that will be rendered.
 
 Context Variables
@@ -260,13 +260,13 @@ Optional Arguments
 ``template_name``
     default
         'schedule/calendar_by_period.html'
-    
+
     This is the template that will be rendered, if this view is accessed via GET.
 
 ``next``
     default
         the event detail page of ``occurrence.event``
-    
+
     This is the url you wish to be redirected to after a successful cancelation.
 
 Context Variables
@@ -296,7 +296,7 @@ Optional Arguments
 ``template_name``
     default
         'schedule/calendar_by_period.html'
-    
+
     This is the template that will be rendered.
 
 ``event_id``
@@ -335,7 +335,7 @@ Optional Arguments
 ``template_name``
     default
         'schedule/calendar_by_period.html'
-    
+
     This is the template that will be rendered.
 
 ``next``
@@ -344,7 +344,7 @@ Optional Arguments
 ``login_required``
     default
         ``True``
-    
+
     If you want to require a login before deletion happens you can set that here.
 
 Context Variables

--- a/schedule/templates/fullcalendar_script.html
+++ b/schedule/templates/fullcalendar_script.html
@@ -62,13 +62,13 @@ $(document).ready(function() {
                         /789/, event.second);
             }
         }
-        
+
         $('#allevent').attr('href', all_url);
         $('#thisevent').attr('href', this_url);
         $('#editordelete').html(type);
         $('#EditorDelete').html(tYPE);
     }
-    
+
     function getCookie(name) {
         var cookieValue = null;
         if (document.cookie && document.cookie != '') {
@@ -160,7 +160,7 @@ $(document).ready(function() {
             }
         },
         dayClick: function(date, allDay, jsEvent, view) {
-                    if (allDay) {       
+                    if (allDay) {
                         $('#calendar').fullCalendar('changeView', 'agendaWeek');
                         $("#calendar").fullCalendar('gotoDate', date);
                     }
@@ -177,7 +177,7 @@ $(document).ready(function() {
                         'delta' : delta.asMinutes(),
                     },
                     success : function(result) {
-                        if (result.success) $('#feedback input').attr('value', ''); 
+                        if (result.success) $('#feedback input').attr('value', '');
                         $('#calendar').fullCalendar('refetchEvents');
                         },
                     error : function(req, status, error) {
@@ -199,7 +199,7 @@ $(document).ready(function() {
                         'resize' : true,
                     },
                     success : function(result) {
-                        if (result.success) $('#feedback input').attr('value', ''); 
+                        if (result.success) $('#feedback input').attr('value', '');
                         $('#calendar').fullCalendar('refetchEvents');
                         },
                     error : function(req, status, error) {
@@ -222,7 +222,7 @@ $(document).ready(function() {
                         },
                         success : function(result) {
                             console.log(result);
-                            if (result.success) $('#feedback input').attr('value', ''); 
+                            if (result.success) $('#feedback input').attr('value', '');
                             $('#calendar').fullCalendar('refetchEvents');
                             },
                         error : function(req, status, error) {

--- a/schedule/templates/schedule/_dialogs.html
+++ b/schedule/templates/schedule/_dialogs.html
@@ -7,4 +7,3 @@
 <div style="display:none;" id="edit_dialog" title="This is a recurring event">
   {% trans "Do you want to edit this occurrence or all occurrences?" %}
 </div>
-


### PR DESCRIPTION
Many editors clean up trailing white space on save. By removing it all
in one go, it helps keep future diffs cleaner by avoiding spurious white
space changes on unrelated lines.