### PR TITLE
Fix all Sphinx warnings displayed when generating docs

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
+SPHINXOPTS    = -n -W
 SPHINXBUILD   = sphinx-build
 PAPER         =
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -121,7 +121,7 @@ html_theme = 'default'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+#html_static_path = ['_static']
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.

--- a/docs/install.txt
+++ b/docs/install.txt
@@ -1,4 +1,5 @@
 .. _ref-install:
+
 =======
 Install
 =======

--- a/docs/overview.txt
+++ b/docs/overview.txt
@@ -37,7 +37,7 @@ Because some Event can recur indefinitely, you cannot have a function like,
 This gives you a list of all occurrences that occur inclusively after start and exclusively before end.  When we say occur, that means that they exist at all between start and end. If occurrence ends 10 seconds after ``start`` then it will be in the list, and if an occurrence starts 10 seconds before ``end`` then it will also be in the list.
 
 ``occurrences_after(after)``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 This method produces a generator that generates events inclusively after the given datetime ``after``.  If no date is given then it uses now.
 

--- a/docs/settings.txt
+++ b/docs/settings.txt
@@ -8,7 +8,7 @@ Settings
 OCCURRENCE_CANCEL_REDIRECT
 --------------------------
 
-This setting controls the behavior of :func:`Views.get_next_url`. If set, all calendar modifications will redirect here (unless there is a `next` set in the request.)
+This setting controls the behavior of ``Views.get_next_url``. If set, all calendar modifications will redirect here (unless there is a `next` set in the request.)
 
 .. _ref-settings-show-cancelled-occurrences:
 
@@ -36,7 +36,7 @@ If ob is None, then the function is checking for permission to add new events.
 .. _ref-settings-check-calendar-perm-func:
 
 CHECK_CALENDAR_PERM_FUNC
----------------------
+------------------------
 
 This setting controls the callable used to determine if a user has permission to add, update or delete events in a specific calendar. The callable must take the object (calendar) and the user and return a boolean.
 


### PR DESCRIPTION
Warnings previously appeared as:

```
django-scheduler/docs/install.txt:2: WARNING: Explicit markup ends without a blank line; unexpected unindent.
django-scheduler/docs/overview.txt:40: WARNING: Title underline too short.
django-scheduler/docs/overview.txt:40: WARNING: Title underline too short.
django-scheduler/docs/settings.txt:39: WARNING: Title underline too short.
django-scheduler/docs/settings.txt:39: WARNING: Title underline too short.

WARNING: html_static_path entry u'django-scheduler/docs/_static' does not exist
```