### PR TITLE
Remove workaround for older prefetch_related_objects() API

### DIFF
--- a/schedule/periods.py
+++ b/schedule/periods.py
@@ -82,10 +82,7 @@ class Period(object):
                     occurrences.append(occurrence)
             return occurrences
 
-        try:
-            prefetch_related_objects(self.events, 'occurrence_set')
-        except AttributeError:
-            prefetch_related_objects(self.events, ['occurrence_set'])
+        prefetch_related_objects(self.events, 'occurrence_set')
         for event in self.events:
             event_occurrences = event.get_occurrences(self.start, self.end, clear_prefetch=False)
             occurrences += event_occurrences


### PR DESCRIPTION
Was stabilized in Django 1.10 and has remained the same since.