### PR TITLE
Multi slugs

### DIFF
--- a/schedule/views.py
+++ b/schedule/views.py
@@ -298,18 +298,20 @@ def get_next_url(request, default):
 def api_occurrences(request):
     start = request.GET.get('start')
     end = request.GET.get('end')
-    calendar_slug = request.GET.get('calendar_slug')
     timezone = request.GET.get('timezone')
 
+    calendar_slugs_raw = request.GET.get('calendar_slug')
+    calendar_slugs = calendar_slugs_raw.split(',') if calendar_slugs_raw else []
+
     try:
-        response_data = _api_occurrences(start, end, calendar_slug, timezone)
+        response_data = _api_occurrences(start, end, calendar_slugs, timezone)
     except (ValueError, Calendar.DoesNotExist) as e:
         return HttpResponseBadRequest(e)
 
     return JsonResponse(response_data, safe=False)
 
 
-def _api_occurrences(start, end, calendar_slug, timezone):
+def _api_occurrences(start, end, calendar_slugs, timezone):
 
     if not start or not end:
         raise ValueError('Start and end parameters are required')
@@ -343,9 +345,14 @@ def _api_occurrences(start, end, calendar_slug, timezone):
         start = utc.localize(start)
         end = utc.localize(end)
 
-    if calendar_slug:
+    if calendar_slugs:
         # will raise DoesNotExist exception if no match
-        calendars = [Calendar.objects.get(slug=calendar_slug)]
+        calendars = list(Calendar.objects.filter(slug__in=calendar_slugs))
+        missing_calendars = set(calendar_slugs) - set([s.slug for s in calendars])
+        if missing_calendars:
+            missing_msg = ", ".join("'{0}'".format(s) for s in missing_calendars)
+            msg = "Calendars {0} do not exist.".format(missing_msg)
+            raise Calendar.DoesNotExist(missing_calendars)
     # if no calendar slug is given, get all the calendars
     else:
         calendars = Calendar.objects.all()

--- a/schedule/views.py
+++ b/schedule/views.py
@@ -298,18 +298,20 @@ def get_next_url(request, default):
 def api_occurrences(request):
     start = request.GET.get('start')
     end = request.GET.get('end')
-    calendar_slug = request.GET.get('calendar_slug')
+    calendar_slugs_raw = request.GET.get('calendar_slug')
     timezone = request.GET.get('timezone')
 
+    calendar_slugs = calendar_slugs_raw.split(',') if calendar_slugs_raw else []
+
     try:
-        response_data = _api_occurrences(start, end, calendar_slug, timezone)
+        response_data = _api_occurrences(start, end, calendar_slugs, timezone)
     except (ValueError, Calendar.DoesNotExist) as e:
         return HttpResponseBadRequest(e)
 
     return JsonResponse(response_data, safe=False)
 
 
-def _api_occurrences(start, end, calendar_slug, timezone):
+def _api_occurrences(start, end, calendar_slugs, timezone):
 
     if not start or not end:
         raise ValueError('Start and end parameters are required')
@@ -343,9 +345,14 @@ def _api_occurrences(start, end, calendar_slug, timezone):
         start = utc.localize(start)
         end = utc.localize(end)
 
-    if calendar_slug:
+    if calendar_slugs:
         # will raise DoesNotExist exception if no match
-        calendars = [Calendar.objects.get(slug=calendar_slug)]
+        calendars = list(Calendar.objects.filter(slug__in=calendar_slugs))
+        missing_calendars = set(calendar_slugs) - set([s.slug for s in calendars])
+        if missing_calendars:
+            missing_msg = ", ".join("'{0}'".format(s) for s in missing_calendars)
+            msg = "Calendars {0} does not exist.".format(missing_msg)
+            raise Calendar.DoesNotExist(missing_calendars)
     # if no calendar slug is given, get all the calendars
     else:
         calendars = Calendar.objects.all()

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -67,7 +67,7 @@ class TestViewUtils(TestCase):
 
     def test_get_occurrence_persisted(self):
         date = timezone.make_aware(datetime.datetime(year=2008, month=1,
-                                                     day=5, hour=8, minute=0, second=0),
+                                   day=5, hour=8, minute=0, second=0),
                                    pytz.utc)
         occurrence = self.event.get_occurrence(date)
         occurrence.save()
@@ -202,10 +202,7 @@ class TestUrls(TestCase):
             reverse("api_occurrences") + "?calendar={}&start={}&end={}".format(
                 'MyCal', datetime.datetime(2008, 1, 5), datetime.datetime(2008, 1, 6)))
         self.assertEqual(response.status_code, 200)
-        expected_content = [
-            {'existed': False, 'end': '2008-01-05T09:00:00Z', 'description': '', 'creator': 'None', 'color': '',
-             'title': 'Recent Event', 'rule': '', 'event_id': 8, 'end_recurring_period': '2008-05-05T00:00:00Z',
-             'cancelled': False, 'calendar': 'MyCalSlug', 'start': '2008-01-05T08:00:00Z', 'id': 9}]
+        expected_content = [{'existed': False, 'end': '2008-01-05T09:00:00Z', 'description': '', 'creator': 'None', 'color': '', 'title': 'Recent Event', 'rule': '', 'event_id': 8, 'end_recurring_period': '2008-05-05T00:00:00Z', 'cancelled': False, 'calendar': 'MyCalSlug', 'start': '2008-01-05T08:00:00Z', 'id': 9}]
         self.assertEqual(json.loads(response.content.decode()), expected_content)
 
     def test_occurrences_api_without_parameters_return_status_400(self):
@@ -247,20 +244,7 @@ class TestUrls(TestCase):
                 datetime.datetime(2008, 1, 5),
                 datetime.datetime(2008, 1, 8)))
         self.assertEqual(response.status_code, 200)
-        expected_content = [
-            {'existed': False, 'end': '2008-01-05T09:00:00Z', 'description': '', 'creator': 'None', 'color': '',
-             'title': 'Recent Event', 'rule': '', 'event_id': 8, 'end_recurring_period': '2008-01-08T00:00:00Z',
-             'cancelled': False, 'calendar': 'MyCalSlug', 'start': '2008-01-05T08:00:00Z', 'id': 10},
-            {'existed': False, 'end': '2008-01-06T09:00:00Z', 'description': '', 'creator': 'None', 'color': '',
-             'title': 'Recent Event', 'rule': '', 'event_id': 8, 'end_recurring_period': '2008-01-08T00:00:00Z',
-             'cancelled': False, 'calendar': 'MyCalSlug', 'start': '2008-01-06T08:00:00Z', 'id': 10},
-            {'existed': False, 'end': '2008-01-07T09:00:00Z', 'description': '', 'creator': 'None', 'color': '',
-             'title': 'Recent Event', 'rule': '', 'event_id': 8, 'end_recurring_period': '2008-01-08T00:00:00Z',
-             'cancelled': False, 'calendar': 'MyCalSlug', 'start': '2008-01-07T08:00:00Z', 'id': 10},
-            {'existed': True, 'end': '2008-01-07T08:00:00Z', 'description': 'Persisted occ test', 'creator': 'None',
-             'color': '', 'title': 'My persisted Occ', 'rule': '', 'event_id': 8,
-             'end_recurring_period': '2008-01-08T00:00:00Z', 'cancelled': False, 'calendar': 'MyCalSlug',
-             'start': '2008-01-07T08:00:00Z', 'id': 1}]
+        expected_content = [{'existed': False, 'end': '2008-01-05T09:00:00Z', 'description': '', 'creator': 'None', 'color': '', 'title': 'Recent Event', 'rule': '', 'event_id': 8, 'end_recurring_period': '2008-01-08T00:00:00Z', 'cancelled': False, 'calendar': 'MyCalSlug', 'start': '2008-01-05T08:00:00Z', 'id': 10}, {'existed': False, 'end': '2008-01-06T09:00:00Z', 'description': '', 'creator': 'None', 'color': '', 'title': 'Recent Event', 'rule': '', 'event_id': 8, 'end_recurring_period': '2008-01-08T00:00:00Z', 'cancelled': False, 'calendar': 'MyCalSlug', 'start': '2008-01-06T08:00:00Z', 'id': 10}, {'existed': False, 'end': '2008-01-07T09:00:00Z', 'description': '', 'creator': 'None', 'color': '', 'title': 'Recent Event', 'rule': '', 'event_id': 8, 'end_recurring_period': '2008-01-08T00:00:00Z', 'cancelled': False, 'calendar': 'MyCalSlug', 'start': '2008-01-07T08:00:00Z', 'id': 10}, {'existed': True, 'end': '2008-01-07T08:00:00Z', 'description': 'Persisted occ test', 'creator': 'None', 'color': '', 'title': 'My persisted Occ', 'rule': '', 'event_id': 8, 'end_recurring_period': '2008-01-08T00:00:00Z', 'cancelled': False, 'calendar': 'MyCalSlug', 'start': '2008-01-07T08:00:00Z', 'id': 1}]
         self.assertEqual(json.loads(response.content.decode()), expected_content)
         # test timezone param
         response = self.client.get(
@@ -270,23 +254,7 @@ class TestUrls(TestCase):
                 datetime.datetime(2008, 1, 8),
                 'America/Chicago'))
         self.assertEqual(response.status_code, 200)
-        expected_content = [
-            {u'existed': False, u'end': u'2008-01-05T03:00:00-06:00', u'description': '', u'creator': u'None',
-             u'color': '', u'title': u'Recent Event', u'rule': u'', u'event_id': 8,
-             u'end_recurring_period': u'2008-01-07T18:00:00-06:00', u'cancelled': False, u'calendar': u'MyCalSlug',
-             u'start': u'2008-01-05T02:00:00-06:00', u'id': 10},
-            {u'existed': False, u'end': u'2008-01-06T03:00:00-06:00', u'description': '', u'creator': u'None',
-             u'color': '', u'title': u'Recent Event', u'rule': u'', u'event_id': 8,
-             u'end_recurring_period': u'2008-01-07T18:00:00-06:00', u'cancelled': False, u'calendar': u'MyCalSlug',
-             u'start': u'2008-01-06T02:00:00-06:00', u'id': 10},
-            {u'existed': False, u'end': u'2008-01-07T03:00:00-06:00', u'description': '', u'creator': u'None',
-             u'color': '', u'title': u'Recent Event', u'rule': u'', u'event_id': 8,
-             u'end_recurring_period': u'2008-01-07T18:00:00-06:00', u'cancelled': False, u'calendar': u'MyCalSlug',
-             u'start': u'2008-01-07T02:00:00-06:00', u'id': 10},
-            {u'existed': True, u'end': u'2008-01-07T02:00:00-06:00', u'description': u'Persisted occ test',
-             u'creator': u'None', u'color': '', u'title': u'My persisted Occ', u'rule': u'', u'event_id': 8,
-             u'end_recurring_period': u'2008-01-07T18:00:00-06:00', u'cancelled': False, u'calendar': u'MyCalSlug',
-             u'start': u'2008-01-07T02:00:00-06:00', u'id': 1}]
+        expected_content = [{u'existed': False, u'end': u'2008-01-05T03:00:00-06:00', u'description': '', u'creator': u'None', u'color': '', u'title': u'Recent Event', u'rule': u'', u'event_id': 8, u'end_recurring_period': u'2008-01-07T18:00:00-06:00', u'cancelled': False, u'calendar': u'MyCalSlug', u'start': u'2008-01-05T02:00:00-06:00', u'id': 10}, {u'existed': False, u'end': u'2008-01-06T03:00:00-06:00', u'description': '', u'creator': u'None', u'color': '', u'title': u'Recent Event', u'rule': u'', u'event_id': 8, u'end_recurring_period': u'2008-01-07T18:00:00-06:00', u'cancelled': False, u'calendar': u'MyCalSlug', u'start': u'2008-01-06T02:00:00-06:00', u'id': 10}, {u'existed': False, u'end': u'2008-01-07T03:00:00-06:00', u'description': '', u'creator': u'None', u'color': '', u'title': u'Recent Event', u'rule': u'', u'event_id': 8, u'end_recurring_period': u'2008-01-07T18:00:00-06:00', u'cancelled': False, u'calendar': u'MyCalSlug', u'start': u'2008-01-07T02:00:00-06:00', u'id': 10}, {u'existed': True, u'end': u'2008-01-07T02:00:00-06:00', u'description': u'Persisted occ test', u'creator': u'None', u'color': '', u'title': u'My persisted Occ', u'rule': u'', u'event_id': 8, u'end_recurring_period': u'2008-01-07T18:00:00-06:00', u'cancelled': False, u'calendar': u'MyCalSlug', u'start': u'2008-01-07T02:00:00-06:00', u'id': 1}]
         self.assertEqual(json.loads(response.content.decode()), expected_content)
 
     def test_occurrences_api_works_with_and_without_cal_slug(self):
@@ -335,7 +303,7 @@ class TestUrls(TestCase):
         # Test both present with no cal arg
         response = self.client.get(reverse("api_occurrences"),
                                    {'start': '2008-01-05',
-                                    'end': '2008-02-05'}
+                                   'end': '2008-02-05'}
                                    )
         self.assertEqual(response.status_code, 200)
         resp_list = json.loads(response.content.decode('utf-8'))
@@ -400,47 +368,6 @@ class TestUrls(TestCase):
         resp = response.content.decode('utf-8')
         expected_error = "does not match format '%Y-%m-%dT%H:%M:%S'"
         self.assertIn(expected_error, resp)
-
-    def test_cal_multiple_slugs_return_all_events(self):
-        calendar1 = Calendar.objects.create(name="MyCal1", slug='MyCalSlug1')
-        calendar2 = Calendar.objects.create(name="MyCal2", slug='MyCalSlug2')
-        calendarOther = Calendar.objects.create(name="MyCalOther", slug='MyCalSlugOther')
-
-        event1 = Event.objects.create(
-            title='Recent Event 1',
-            start=datetime.datetime(2008, 1, 5, 8, 0, tzinfo=pytz.utc),
-            end=datetime.datetime(2008, 1, 5, 9, 0, tzinfo=pytz.utc),
-            end_recurring_period=datetime.datetime(2008, 5, 5, 0, 0, tzinfo=pytz.utc),
-            calendar=calendar1,
-        )
-        event2 = Event.objects.create(
-            title='Recent Event 2',
-            start=datetime.datetime(2008, 1, 5, 8, 0, tzinfo=pytz.utc),
-            end=datetime.datetime(2008, 1, 5, 9, 0, tzinfo=pytz.utc),
-            end_recurring_period=datetime.datetime(2008, 5, 5, 0, 0, tzinfo=pytz.utc),
-            calendar=calendar2,
-        )
-
-        eventOther = Event.objects.create(
-            title='Recent Event Other',
-            start=datetime.datetime(2008, 1, 5, 8, 0, tzinfo=pytz.utc),
-            end=datetime.datetime(2008, 1, 5, 9, 0, tzinfo=pytz.utc),
-            end_recurring_period=datetime.datetime(2008, 5, 5, 0, 0, tzinfo=pytz.utc),
-            calendar=calendarOther,
-        )
-
-        # Test both present with no cal arg
-        response = self.client.get(reverse("api_occurrences"),
-                                   {'start': '2008-01-05',
-                                    'end': '2008-02-05',
-                                    'calendar_slug': ','.join(['MyCalSlug1','MyCalSlug2',]), }
-                                   )
-        self.assertEqual(response.status_code, 200)
-        resp_list = json.loads(response.content.decode('utf-8'))
-        self.assertIn(event1.title, [d['title'] for d in resp_list])
-        self.assertIn(event2.title, [d['title'] for d in resp_list])
-
-        self.assertNotIn(eventOther.title, [d['title'] for d in resp_list])
 
     def test_check_next_url_valid_case(self):
         expected = '/calendar/1'

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -369,6 +369,47 @@ class TestUrls(TestCase):
         expected_error = "does not match format '%Y-%m-%dT%H:%M:%S'"
         self.assertIn(expected_error, resp)
 
+    def test_cal_multiple_slugs_return_all_events(self):
+        calendar1 = Calendar.objects.create(name="MyCal1", slug='MyCalSlug1')
+        calendar2 = Calendar.objects.create(name="MyCal2", slug='MyCalSlug2')
+        calendarOther = Calendar.objects.create(name="MyCalOther", slug='MyCalSlugOther')
+
+        event1 = Event.objects.create(
+            title='Recent Event 1',
+            start=datetime.datetime(2008, 1, 5, 8, 0, tzinfo=pytz.utc),
+            end=datetime.datetime(2008, 1, 5, 9, 0, tzinfo=pytz.utc),
+            end_recurring_period=datetime.datetime(2008, 5, 5, 0, 0, tzinfo=pytz.utc),
+            calendar=calendar1,
+        )
+        event2 = Event.objects.create(
+            title='Recent Event 2',
+            start=datetime.datetime(2008, 1, 5, 8, 0, tzinfo=pytz.utc),
+            end=datetime.datetime(2008, 1, 5, 9, 0, tzinfo=pytz.utc),
+            end_recurring_period=datetime.datetime(2008, 5, 5, 0, 0, tzinfo=pytz.utc),
+            calendar=calendar2,
+        )
+
+        eventOther = Event.objects.create(
+            title='Recent Event Other',
+            start=datetime.datetime(2008, 1, 5, 8, 0, tzinfo=pytz.utc),
+            end=datetime.datetime(2008, 1, 5, 9, 0, tzinfo=pytz.utc),
+            end_recurring_period=datetime.datetime(2008, 5, 5, 0, 0, tzinfo=pytz.utc),
+            calendar=calendarOther,
+        )
+
+        # Test both present with no cal arg
+        response = self.client.get(reverse("api_occurrences"),
+                                   {'start': '2008-01-05',
+                                    'end': '2008-02-05',
+                                    'calendar_slug': ','.join(['MyCalSlug1','MyCalSlug2',]), }
+                                   )
+        self.assertEqual(response.status_code, 200)
+        resp_list = json.loads(response.content.decode('utf-8'))
+        self.assertIn(event1.title, [d['title'] for d in resp_list])
+        self.assertIn(event2.title, [d['title'] for d in resp_list])
+
+        self.assertNotIn(eventOther.title, [d['title'] for d in resp_list])
+
     def test_check_next_url_valid_case(self):
         expected = '/calendar/1'
         res = check_next_url('/calendar/1')

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -67,7 +67,7 @@ class TestViewUtils(TestCase):
 
     def test_get_occurrence_persisted(self):
         date = timezone.make_aware(datetime.datetime(year=2008, month=1,
-                                   day=5, hour=8, minute=0, second=0),
+                                                     day=5, hour=8, minute=0, second=0),
                                    pytz.utc)
         occurrence = self.event.get_occurrence(date)
         occurrence.save()
@@ -202,7 +202,10 @@ class TestUrls(TestCase):
             reverse("api_occurrences") + "?calendar={}&start={}&end={}".format(
                 'MyCal', datetime.datetime(2008, 1, 5), datetime.datetime(2008, 1, 6)))
         self.assertEqual(response.status_code, 200)
-        expected_content = [{'existed': False, 'end': '2008-01-05T09:00:00Z', 'description': '', 'creator': 'None', 'color': '', 'title': 'Recent Event', 'rule': '', 'event_id': 8, 'end_recurring_period': '2008-05-05T00:00:00Z', 'cancelled': False, 'calendar': 'MyCalSlug', 'start': '2008-01-05T08:00:00Z', 'id': 9}]
+        expected_content = [
+            {'existed': False, 'end': '2008-01-05T09:00:00Z', 'description': '', 'creator': 'None', 'color': '',
+             'title': 'Recent Event', 'rule': '', 'event_id': 8, 'end_recurring_period': '2008-05-05T00:00:00Z',
+             'cancelled': False, 'calendar': 'MyCalSlug', 'start': '2008-01-05T08:00:00Z', 'id': 9}]
         self.assertEqual(json.loads(response.content.decode()), expected_content)
 
     def test_occurrences_api_without_parameters_return_status_400(self):
@@ -244,7 +247,20 @@ class TestUrls(TestCase):
                 datetime.datetime(2008, 1, 5),
                 datetime.datetime(2008, 1, 8)))
         self.assertEqual(response.status_code, 200)
-        expected_content = [{'existed': False, 'end': '2008-01-05T09:00:00Z', 'description': '', 'creator': 'None', 'color': '', 'title': 'Recent Event', 'rule': '', 'event_id': 8, 'end_recurring_period': '2008-01-08T00:00:00Z', 'cancelled': False, 'calendar': 'MyCalSlug', 'start': '2008-01-05T08:00:00Z', 'id': 10}, {'existed': False, 'end': '2008-01-06T09:00:00Z', 'description': '', 'creator': 'None', 'color': '', 'title': 'Recent Event', 'rule': '', 'event_id': 8, 'end_recurring_period': '2008-01-08T00:00:00Z', 'cancelled': False, 'calendar': 'MyCalSlug', 'start': '2008-01-06T08:00:00Z', 'id': 10}, {'existed': False, 'end': '2008-01-07T09:00:00Z', 'description': '', 'creator': 'None', 'color': '', 'title': 'Recent Event', 'rule': '', 'event_id': 8, 'end_recurring_period': '2008-01-08T00:00:00Z', 'cancelled': False, 'calendar': 'MyCalSlug', 'start': '2008-01-07T08:00:00Z', 'id': 10}, {'existed': True, 'end': '2008-01-07T08:00:00Z', 'description': 'Persisted occ test', 'creator': 'None', 'color': '', 'title': 'My persisted Occ', 'rule': '', 'event_id': 8, 'end_recurring_period': '2008-01-08T00:00:00Z', 'cancelled': False, 'calendar': 'MyCalSlug', 'start': '2008-01-07T08:00:00Z', 'id': 1}]
+        expected_content = [
+            {'existed': False, 'end': '2008-01-05T09:00:00Z', 'description': '', 'creator': 'None', 'color': '',
+             'title': 'Recent Event', 'rule': '', 'event_id': 8, 'end_recurring_period': '2008-01-08T00:00:00Z',
+             'cancelled': False, 'calendar': 'MyCalSlug', 'start': '2008-01-05T08:00:00Z', 'id': 10},
+            {'existed': False, 'end': '2008-01-06T09:00:00Z', 'description': '', 'creator': 'None', 'color': '',
+             'title': 'Recent Event', 'rule': '', 'event_id': 8, 'end_recurring_period': '2008-01-08T00:00:00Z',
+             'cancelled': False, 'calendar': 'MyCalSlug', 'start': '2008-01-06T08:00:00Z', 'id': 10},
+            {'existed': False, 'end': '2008-01-07T09:00:00Z', 'description': '', 'creator': 'None', 'color': '',
+             'title': 'Recent Event', 'rule': '', 'event_id': 8, 'end_recurring_period': '2008-01-08T00:00:00Z',
+             'cancelled': False, 'calendar': 'MyCalSlug', 'start': '2008-01-07T08:00:00Z', 'id': 10},
+            {'existed': True, 'end': '2008-01-07T08:00:00Z', 'description': 'Persisted occ test', 'creator': 'None',
+             'color': '', 'title': 'My persisted Occ', 'rule': '', 'event_id': 8,
+             'end_recurring_period': '2008-01-08T00:00:00Z', 'cancelled': False, 'calendar': 'MyCalSlug',
+             'start': '2008-01-07T08:00:00Z', 'id': 1}]
         self.assertEqual(json.loads(response.content.decode()), expected_content)
         # test timezone param
         response = self.client.get(
@@ -254,7 +270,23 @@ class TestUrls(TestCase):
                 datetime.datetime(2008, 1, 8),
                 'America/Chicago'))
         self.assertEqual(response.status_code, 200)
-        expected_content = [{u'existed': False, u'end': u'2008-01-05T03:00:00-06:00', u'description': '', u'creator': u'None', u'color': '', u'title': u'Recent Event', u'rule': u'', u'event_id': 8, u'end_recurring_period': u'2008-01-07T18:00:00-06:00', u'cancelled': False, u'calendar': u'MyCalSlug', u'start': u'2008-01-05T02:00:00-06:00', u'id': 10}, {u'existed': False, u'end': u'2008-01-06T03:00:00-06:00', u'description': '', u'creator': u'None', u'color': '', u'title': u'Recent Event', u'rule': u'', u'event_id': 8, u'end_recurring_period': u'2008-01-07T18:00:00-06:00', u'cancelled': False, u'calendar': u'MyCalSlug', u'start': u'2008-01-06T02:00:00-06:00', u'id': 10}, {u'existed': False, u'end': u'2008-01-07T03:00:00-06:00', u'description': '', u'creator': u'None', u'color': '', u'title': u'Recent Event', u'rule': u'', u'event_id': 8, u'end_recurring_period': u'2008-01-07T18:00:00-06:00', u'cancelled': False, u'calendar': u'MyCalSlug', u'start': u'2008-01-07T02:00:00-06:00', u'id': 10}, {u'existed': True, u'end': u'2008-01-07T02:00:00-06:00', u'description': u'Persisted occ test', u'creator': u'None', u'color': '', u'title': u'My persisted Occ', u'rule': u'', u'event_id': 8, u'end_recurring_period': u'2008-01-07T18:00:00-06:00', u'cancelled': False, u'calendar': u'MyCalSlug', u'start': u'2008-01-07T02:00:00-06:00', u'id': 1}]
+        expected_content = [
+            {u'existed': False, u'end': u'2008-01-05T03:00:00-06:00', u'description': '', u'creator': u'None',
+             u'color': '', u'title': u'Recent Event', u'rule': u'', u'event_id': 8,
+             u'end_recurring_period': u'2008-01-07T18:00:00-06:00', u'cancelled': False, u'calendar': u'MyCalSlug',
+             u'start': u'2008-01-05T02:00:00-06:00', u'id': 10},
+            {u'existed': False, u'end': u'2008-01-06T03:00:00-06:00', u'description': '', u'creator': u'None',
+             u'color': '', u'title': u'Recent Event', u'rule': u'', u'event_id': 8,
+             u'end_recurring_period': u'2008-01-07T18:00:00-06:00', u'cancelled': False, u'calendar': u'MyCalSlug',
+             u'start': u'2008-01-06T02:00:00-06:00', u'id': 10},
+            {u'existed': False, u'end': u'2008-01-07T03:00:00-06:00', u'description': '', u'creator': u'None',
+             u'color': '', u'title': u'Recent Event', u'rule': u'', u'event_id': 8,
+             u'end_recurring_period': u'2008-01-07T18:00:00-06:00', u'cancelled': False, u'calendar': u'MyCalSlug',
+             u'start': u'2008-01-07T02:00:00-06:00', u'id': 10},
+            {u'existed': True, u'end': u'2008-01-07T02:00:00-06:00', u'description': u'Persisted occ test',
+             u'creator': u'None', u'color': '', u'title': u'My persisted Occ', u'rule': u'', u'event_id': 8,
+             u'end_recurring_period': u'2008-01-07T18:00:00-06:00', u'cancelled': False, u'calendar': u'MyCalSlug',
+             u'start': u'2008-01-07T02:00:00-06:00', u'id': 1}]
         self.assertEqual(json.loads(response.content.decode()), expected_content)
 
     def test_occurrences_api_works_with_and_without_cal_slug(self):
@@ -303,7 +335,7 @@ class TestUrls(TestCase):
         # Test both present with no cal arg
         response = self.client.get(reverse("api_occurrences"),
                                    {'start': '2008-01-05',
-                                   'end': '2008-02-05'}
+                                    'end': '2008-02-05'}
                                    )
         self.assertEqual(response.status_code, 200)
         resp_list = json.loads(response.content.decode('utf-8'))
@@ -368,6 +400,47 @@ class TestUrls(TestCase):
         resp = response.content.decode('utf-8')
         expected_error = "does not match format '%Y-%m-%dT%H:%M:%S'"
         self.assertIn(expected_error, resp)
+
+    def test_cal_multiple_slugs_return_all_events(self):
+        calendar1 = Calendar.objects.create(name="MyCal1", slug='MyCalSlug1')
+        calendar2 = Calendar.objects.create(name="MyCal2", slug='MyCalSlug2')
+        calendarOther = Calendar.objects.create(name="MyCalOther", slug='MyCalSlugOther')
+
+        event1 = Event.objects.create(
+            title='Recent Event 1',
+            start=datetime.datetime(2008, 1, 5, 8, 0, tzinfo=pytz.utc),
+            end=datetime.datetime(2008, 1, 5, 9, 0, tzinfo=pytz.utc),
+            end_recurring_period=datetime.datetime(2008, 5, 5, 0, 0, tzinfo=pytz.utc),
+            calendar=calendar1,
+        )
+        event2 = Event.objects.create(
+            title='Recent Event 2',
+            start=datetime.datetime(2008, 1, 5, 8, 0, tzinfo=pytz.utc),
+            end=datetime.datetime(2008, 1, 5, 9, 0, tzinfo=pytz.utc),
+            end_recurring_period=datetime.datetime(2008, 5, 5, 0, 0, tzinfo=pytz.utc),
+            calendar=calendar2,
+        )
+
+        eventOther = Event.objects.create(
+            title='Recent Event Other',
+            start=datetime.datetime(2008, 1, 5, 8, 0, tzinfo=pytz.utc),
+            end=datetime.datetime(2008, 1, 5, 9, 0, tzinfo=pytz.utc),
+            end_recurring_period=datetime.datetime(2008, 5, 5, 0, 0, tzinfo=pytz.utc),
+            calendar=calendarOther,
+        )
+
+        # Test both present with no cal arg
+        response = self.client.get(reverse("api_occurrences"),
+                                   {'start': '2008-01-05',
+                                    'end': '2008-02-05',
+                                    'calendar_slug': ','.join(['MyCalSlug1','MyCalSlug2',]), }
+                                   )
+        self.assertEqual(response.status_code, 200)
+        resp_list = json.loads(response.content.decode('utf-8'))
+        self.assertIn(event1.title, [d['title'] for d in resp_list])
+        self.assertIn(event2.title, [d['title'] for d in resp_list])
+
+        self.assertNotIn(eventOther.title, [d['title'] for d in resp_list])
 
     def test_check_next_url_valid_case(self):
         expected = '/calendar/1'


### PR DESCRIPTION
Added support to multiple calendar query for api_occurences.

Previous syntax is not broken, multiple calendar slugs should be separated by comma.