### PR TITLE
Improve tox configuration

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ envlist =
     py{35,36,37}-djangomaster
 
 [testenv]
-commands = coverage run -m django test --settings=tests.settings
+commands = {envpython} -Wa -b -m coverage run -m django test --settings=tests.settings
 deps =
     django111: Django>=1.11,<2.0
     django20: Django>=2.0,<2.1
@@ -20,9 +20,8 @@ basepython = python3
 commands =
     flake8
     isort --check-only --diff
-    python -m django check --settings=tests.settings
-    python -m django makemigrations --settings=tests.settings --no-input --dry-run --check
+    {envpython} -m django check --settings=tests.settings
+    {envpython} -m django makemigrations --settings=tests.settings --no-input --dry-run --check
 deps =
     flake8
-    Django>=1.11
     isort


### PR DESCRIPTION
Always specify python with the tox variable {envpython}.

Display warnings when running tests to help discover deprecated
behavior.

Don't bother with Django as a dependency in the "lint" test environment
as it is already a dependency of the project.