### PR TITLE
Test against for Django 2.2 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,8 +35,6 @@ matrix:
       env: TOXENV=py36-django22
     - python: 3.7
       env: TOXENV=py37-django22
-    - python: 3.5
-      env: TOXENV=py35-djangomaster
     - python: 3.6
       env: TOXENV=py36-djangomaster
     - python: 3.7

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist =
     py{34,35,36,37}-django20
     py{35,36,37}-django21
     py{35,36,37}-django22
-    py{35,36,37}-djangomaster
+    py{36,37}-djangomaster
 
 [testenv]
 commands = {envpython} -Wa -b -m coverage run -m django test --settings=tests.settings
@@ -13,7 +13,7 @@ deps =
     django111: Django>=1.11,<2.0
     django20: Django>=2.0,<2.1
     django21: Django>=2.1,<2.2
-    django22: Django>=2.2a1,<2.3
+    django22: Django>=2.2,<2.3
     djangomaster: https://github.com/django/django/archive/master.tar.gz
     coverage
 


### PR DESCRIPTION
Announcement:
https://www.djangoproject.com/weblog/2019/apr/01/django-22-released/

Release notes:
https://docs.djangoproject.com/en/2.2/releases/2.2/

Django master dropped support for Python 3.5.