### PR TITLE
 Add explicit hash declaration in Occurrence for django >=2.2

### DIFF
--- a/schedule/models/events.py
+++ b/schedule/models/events.py
@@ -699,6 +699,11 @@ class Occurrence(models.Model):
     def __lt__(self, other):
         return self.end < other.end
 
+    def __hash__(self):
+        if not self.pk:
+            raise TypeError("Model instances without primary key value are unhashable")
+        return hash(self.pk)
+
     def __eq__(self, other):
         return (
             isinstance(other, Occurrence)

--- a/schedule/models/events.py
+++ b/schedule/models/events.py
@@ -9,8 +9,7 @@ from django.db.models import Q
 from django.template.defaultfilters import date
 from django.urls import reverse
 from django.utils import timezone
-from django.utils.translation import gettext
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext, gettext_lazy as _
 
 from schedule.models.calendars import Calendar
 from schedule.models.rules import Rule

--- a/tests/test_occurrence.py
+++ b/tests/test_occurrence.py
@@ -38,6 +38,14 @@ class TestOccurrence(TestCase):
         self.assertTrue(occurrences[0].pk)
         self.assertFalse(occurrences[1].pk)
 
+    def test_persisted_occurrences_are_hashable(self):
+        occurrences = self.recurring_event.get_occurrences(
+            start=self.start, end=self.end
+        )
+        persisted_occurrence = occurrences[0]
+        persisted_occurrence.save()
+        self.assertEqual(hash(persisted_occurrence), persisted_occurrence.pk)
+
     def test_moved_occurrences(self):
         occurrences = self.recurring_event.get_occurrences(
             start=self.start, end=self.end

--- a/tests/test_occurrence.py
+++ b/tests/test_occurrence.py
@@ -30,6 +30,8 @@ class TestOccurrence(TestCase):
         occurrences = self.recurring_event.get_occurrences(
             start=self.start, end=self.end
         )
+        with self.assertRaises(TypeError):
+            hash(occurrences[0])
         persisted_occurrence = occurrences[0]
         persisted_occurrence.save()
         occurrences = self.recurring_event.get_occurrences(


### PR DESCRIPTION
Solves for the django 2.2 issue with __hash__ not being inherited, but explicitly declaring it (since Django is not going to change their setup). Fixes issue #443 