### PR TITLE
Remove Django 3.0 trove classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,6 @@ setup(
         "Framework :: Django :: 2.0",
         "Framework :: Django :: 2.1",
         "Framework :: Django :: 2.2",
-        "Framework :: Django :: 3.0",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: BSD License",
         "Operating System :: OS Independent",


### PR DESCRIPTION
It is not yet available on PyPI.

Fixes error:

    HTTPError: 400 Client Error: Invalid value for classifiers. Error: 'Framework :: Django :: 3.0' is not a valid choice for this field for url: https://upload.pypi.org/legacy/