### PR TITLE
Remove support for end-of-life Django 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,6 @@ matrix:
     - python: 3.6
       env: TOXENV=py36-django111
     - python: 3.5
-      env: TOXENV=py35-django20
-    - python: 3.6
-      env: TOXENV=py36-django20
-    - python: 3.7
-      env: TOXENV=py37-django20
-    - python: 3.5
       env: TOXENV=py35-django21
     - python: 3.6
       env: TOXENV=py36-django21

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+UNRELEASED
+==========
+
+- Removed support for end-of-life Django 2.0.
+
 0.9.0 - 2019-10-04
 ==================
 

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,6 @@ setup(
         "Environment :: Web Environment",
         "Framework :: Django",
         "Framework :: Django :: 1.11",
-        "Framework :: Django :: 2.0",
         "Framework :: Django :: 2.1",
         "Framework :: Django :: 2.2",
         "Intended Audience :: Developers",

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,6 @@
 envlist =
     lint
     py{35,36}-django111
-    py{35,36,37}-django20
     py{35,36,37}-django21
     py{35,36,37}-django22
     py{36,37}-django30
@@ -12,7 +11,6 @@ envlist =
 commands = {envpython} -Wa -b -m coverage run -m django test --settings=tests.settings
 deps =
     django111: Django>=1.11,<2.0
-    django20: Django>=2.0,<2.1
     django21: Django>=2.1,<2.2
     django22: Django>=2.2,<2.3
     django30: Django>=3.0a1,<3.1


### PR DESCRIPTION
Django 2.0 is no longer supported upstream. Remove it from the test
matrix to reduce testing resources.