### PR TITLE
Fix index collision in 0008_gfk_index migration

### DIFF
--- a/schedule/migrations/0008_gfk_index.py
+++ b/schedule/migrations/0008_gfk_index.py
@@ -27,8 +27,8 @@ class Migration(migrations.Migration):
         ),
         # Drop db_index before creating unique index, to prevent re-creating indices
         migrations.RunSQL(
-            "DROP INDEX schedule_calendar_slug_ba17e861; "
-            "DROP INDEX schedule_calendar_slug_ba17e861_like;"
+            "DROP INDEX IF EXISTS schedule_calendar_slug_ba17e861; "
+            "DROP INDEX IF EXISTS schedule_calendar_slug_ba17e861_like;"
         ),
         migrations.AlterField(
             model_name="calendar",

--- a/schedule/migrations/0008_gfk_index.py
+++ b/schedule/migrations/0008_gfk_index.py
@@ -25,6 +25,11 @@ class Migration(migrations.Migration):
         migrations.AlterIndexTogether(
             name="eventrelation", index_together={("content_type", "object_id")}
         ),
+        # Drop db_index before creating unique index, to prevent re-creating indices
+        migrations.RunSQL(
+            "DROP INDEX schedule_calendar_slug_ba17e861; "
+            "DROP INDEX schedule_calendar_slug_ba17e861_like;"
+        ),
         migrations.AlterField(
             model_name="calendar",
             name="slug",


### PR DESCRIPTION
When schedule migrations are run for the first time, the following exception occurs for migration 0008_gfk_index: `psycopg2.errors.DuplicateTable: relation "schedule_calendar_slug_ba17e861_like" already exists`.

This appears to be due to Django attempting to set the `_like` index after adding `unique=True` to the `Calendar.slug` field, for which `db_index=True` was already set due to being a `SlugField`. The initial migration created the `_like` index, and making an already indexed field unique causes the index collision.

This is the best fix I could come up with. I'll continue investigating and potentially file a bug with Django if it turns out to be trivially reproducible.