### PR TITLE
Add testing for Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,13 +28,18 @@ matrix:
       env: TOXENV=py36-django30
     - python: 3.7
       env: TOXENV=py37-django30
+    - python: 3.8
+      env: TOXENV=py38-django30
     - python: 3.6
       env: TOXENV=py36-djangomaster
     - python: 3.7
       env: TOXENV=py37-djangomaster
+    - python: 3.8
+      env: TOXENV=py38-djangomaster
   allow_failures:
     - env: TOXENV=py36-djangomaster
     - env: TOXENV=py37-djangomaster
+    - env: TOXENV=py38-djangomaster
 
 install:
   - pip install tox

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Topic :: Utilities",
     ],
     python_requires=">=3.5",

--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,8 @@ envlist =
     py{35,36}-django111
     py{35,36,37}-django21
     py{35,36,37}-django22
-    py{36,37}-django30
-    py{36,37}-djangomaster
+    py{36,37,38}-django30
+    py{36,37,38}-djangomaster
 
 [testenv]
 commands = {envpython} -Wa -b -m coverage run -m django test --settings=tests.settings


### PR DESCRIPTION
Supported by Django 3.0.

Python 3.8 was released on October 14th, 2019.