### PR TITLE
Update Calendar.slug max_length to match migrations

### DIFF
--- a/schedule/models/calendars.py
+++ b/schedule/models/calendars.py
@@ -139,7 +139,7 @@ class Calendar(models.Model):
     """
 
     name = models.CharField(_("name"), max_length=200)
-    slug = models.SlugField(_("slug"), max_length=191, unique=True)
+    slug = models.SlugField(_("slug"), max_length=200, unique=True)
     objects = CalendarManager()
 
     class Meta:


### PR DESCRIPTION
Fixes lint error:

    $ python -m django makemigrations --settings=tests.settings --no-input --dry-run --check
    Migrations for 'schedule':
      schedule/migrations/0013_auto_20191031_2212.py
        - Alter field slug on calendar