### PR TITLE
Clear prefetch related caches with public method refresh_from_db()

### DIFF
--- a/schedule/models/events.py
+++ b/schedule/models/events.py
@@ -158,7 +158,7 @@ class Event(models.Model):
         # to override this cache clear since it already fetches all
         # occurrence_sets via prefetch_related in its get_occurrences.
         if clear_prefetch:
-            self.occurrence_set._remove_prefetched_objects()
+            self.refresh_from_db()
 
         persisted_occurrences = self.occurrence_set.all()
         occ_replacer = OccurrenceReplacer(persisted_occurrences)


### PR DESCRIPTION
Change to use public method to clear prefetch related caches instead of using private method.

More information, see:
https://code.djangoproject.com/ticket/29625?cversion=0&cnum_hist=1