### PR TITLE
Rename Django master branch to main

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,16 +28,10 @@ matrix:
       env: TOXENV=py37-django30
     - python: 3.8
       env: TOXENV=py38-django30
-    - python: 3.6
-      env: TOXENV=py36-djangomaster
-    - python: 3.7
-      env: TOXENV=py37-djangomaster
     - python: 3.8
-      env: TOXENV=py38-djangomaster
+      env: TOXENV=py38-djangomain
   allow_failures:
-    - env: TOXENV=py36-djangomaster
-    - env: TOXENV=py37-djangomaster
-    - env: TOXENV=py38-djangomaster
+    - env: TOXENV=py38-djangomain
 
 install:
   - pip install tox

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist =
     py{35,36,37}-django21
     py{35,36,37}-django22
     py{36,37,38}-django30
-    py{36,37,38}-djangomaster
+    py{38}-djangomain
 
 [testenv]
 commands = {envpython} -Wa -b -m coverage run -m django test --settings=tests.settings
@@ -14,7 +14,7 @@ deps =
     django21: Django>=2.1,<2.2
     django22: Django>=2.2,<2.3
     django30: Django>=3.0,<3.1
-    djangomaster: https://github.com/django/django/archive/master.tar.gz
+    djangomain: https://github.com/django/django/archive/main.tar.gz
     coverage
 
 [testenv:lint]


### PR DESCRIPTION
Upstream renamed the branch, follow suit.
The current main branch only supports Python 3.8+, drop older versions.