### PR TITLE
Upgrade isort command to isort>=5

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -22,10 +22,10 @@ basepython = python3
 commands =
     black --target-version py36 --check --diff .
     flake8
-    isort --check-only --diff
+    isort --check-only --diff .
     {envpython} -m django check --settings=tests.settings
     {envpython} -m django makemigrations --settings=tests.settings --no-input --dry-run --check
 deps =
     black
     flake8
-    isort
+    isort>=5.0.2


### PR DESCRIPTION
Minimum version set to 5.0.2 to use complete Black profile.