### PR TITLE
Use default app config discovery

### DIFF
--- a/schedule/__init__.py
+++ b/schedule/__init__.py
@@ -1,1 +1,4 @@
-default_app_config = "schedule.apps.ScheduleConfig"
+import django
+
+if django.VERSION < (3, 2):
+    default_app_config = "schedule.apps.ScheduleConfig"


### PR DESCRIPTION
Django 3.2 deprecated default_app_config.
https://docs.djangoproject.com/en/3.2/releases/3.2/#automatic-appconfig-discovery