### PR TITLE
Specify DEFAULT_AUTO_FIELD in tests settings

### DIFF
--- a/tests/settings.py
+++ b/tests/settings.py
@@ -49,6 +49,7 @@ INSTALLED_APPS = (
 )
 
 DATABASES = {"default": {"ENGINE": "django.db.backends.sqlite3", "NAME": ":memory:"}}
+DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 # Internationalization
 


### PR DESCRIPTION
Avoids Django 3.2 warning:

```
schedule.Rule: (models.W042) Auto-created primary key used when not defining a primary key type, by default 'django.db.models.AutoField'.
        HINT: Configure the DEFAULT_AUTO_FIELD setting or the ScheduleConfig.default_auto_field attribute to point to a subclass of AutoField, e.g. 'django.db.m
odels.BigAutoField'.
```