### PR TITLE
Use url_has_allowed_host_and_scheme instead of is_safe_url

### DIFF
--- a/schedule/views.py
+++ b/schedule/views.py
@@ -14,7 +14,13 @@ from django.http import (
 from django.shortcuts import get_object_or_404
 from django.urls import reverse
 from django.utils import timezone
-from django.utils.http import is_safe_url
+
+try:
+    from django.utils.http import url_has_allowed_host_and_scheme
+except ImportError:
+    # Django<=2.2
+    from django.utils.http import is_safe_url as url_has_allowed_host_and_scheme
+
 from django.views.decorators.http import require_POST
 from django.views.generic.base import TemplateResponseMixin
 from django.views.generic.detail import DetailView
@@ -320,7 +326,7 @@ def get_next_url(request, default):
         if request.method in ["GET", "HEAD"]
         else request.POST.get("next")
     )
-    if _next_url and is_safe_url(url=_next_url, host=request.get_host()):
+    if _next_url and url_has_allowed_host_and_scheme(_next_url, request.get_host()):
         next_url = _next_url
     return next_url
 


### PR DESCRIPTION
Function was renamed in Django to disambiguate its purpose.
https://docs.djangoproject.com/en/dev/releases/3.0/#id3

The host kwarg has been renamed to allowed_hosts in Django 1.11.