### PR TITLE
Use an AutoField until Django 3.2 is the only supported version

### DIFF
--- a/schedule/apps.py
+++ b/schedule/apps.py
@@ -5,3 +5,4 @@ from django.utils.translation import gettext_lazy as _
 class ScheduleConfig(AppConfig):
     name = "schedule"
     verbose_name = _("Schedules")
+    default_auto_field = "django.db.models.AutoField"

--- a/schedule/migrations/0014_use_autofields_for_pk.py
+++ b/schedule/migrations/0014_use_autofields_for_pk.py
@@ -1,0 +1,53 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("schedule", "0013_auto_20210502_2303"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="calendar",
+            name="id",
+            field=models.AutoField(
+                auto_created=True, primary_key=True, serialize=False, verbose_name="ID"
+            ),
+        ),
+        migrations.AlterField(
+            model_name="calendarrelation",
+            name="id",
+            field=models.AutoField(
+                auto_created=True, primary_key=True, serialize=False, verbose_name="ID"
+            ),
+        ),
+        migrations.AlterField(
+            model_name="event",
+            name="id",
+            field=models.AutoField(
+                auto_created=True, primary_key=True, serialize=False, verbose_name="ID"
+            ),
+        ),
+        migrations.AlterField(
+            model_name="eventrelation",
+            name="id",
+            field=models.AutoField(
+                auto_created=True, primary_key=True, serialize=False, verbose_name="ID"
+            ),
+        ),
+        migrations.AlterField(
+            model_name="occurrence",
+            name="id",
+            field=models.AutoField(
+                auto_created=True, primary_key=True, serialize=False, verbose_name="ID"
+            ),
+        ),
+        migrations.AlterField(
+            model_name="rule",
+            name="id",
+            field=models.AutoField(
+                auto_created=True, primary_key=True, serialize=False, verbose_name="ID"
+            ),
+        ),
+    ]


### PR DESCRIPTION
Projects using Django < 3.2 cannot specify the type of their AutoField.
Default to `django.db.models.AutoField` until Django 3.2 is the only
supported version.

https://code.djangoproject.com/ticket/32697#comment:1