### PR TITLE
Added local timezone to obj.occurrences_after as always returns UTC

### DIFF
--- a/schedule/feeds/__init__.py
+++ b/schedule/feeds/__init__.py
@@ -24,7 +24,7 @@ class UpcomingEventsFeed(Feed):
 
     def items(self, obj):
         return itertools.islice(
-            obj.occurrences_after(timezone.now()),
+            obj.occurrences_after(timezone.localtime(timezone.now())),
             getattr(settings, "FEED_LIST_LENGTH", 10),
         )
 


### PR DESCRIPTION
Always returns feed in UTC, changed to returned based on local timezone.