### PR TITLE
Allow override of prev_url and next_url links

### DIFF
--- a/schedule/templates/schedule/_next.html
+++ b/schedule/templates/schedule/_next.html
@@ -1,0 +1,1 @@
+<a href="{{ url|safe }}"><span class="glyphicon glyphicon-circle-arrow-right"></span></a>

--- a/schedule/templates/schedule/_prev.html
+++ b/schedule/templates/schedule/_prev.html
@@ -1,0 +1,1 @@
+<a href="{{ url|safe }}"><span class="glyphicon glyphicon-circle-arrow-left"></span></a>

--- a/schedule/templatetags/scheduletags.py
+++ b/schedule/templatetags/scheduletags.py
@@ -3,11 +3,11 @@ from urllib.parse import urlencode
 
 from django import template
 from django.conf import settings
+from django.template.loader import get_template
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.dateformat import format
 from django.utils.html import escape
-from django.utils.safestring import mark_safe
 
 from schedule.models import Calendar
 from schedule.periods import weekday_abbrs, weekday_names
@@ -209,14 +209,13 @@ def prev_url(target, calendar, period):
     slug = calendar.slug
     if delta.total_seconds() > SCHEDULER_PREVNEXT_LIMIT_SECONDS:
         return ""
-
-    return mark_safe(
-        '<a href="%s%s"><span class="glyphicon glyphicon-circle-arrow-left"></span></a>'
-        % (
+    context = {
+        "url": "{}{}".format(
             reverse(target, kwargs={"calendar_slug": slug}),
             querystring_for_date(period.prev().start),
         )
-    )
+    }
+    return get_template("schedule/_prev.html").render(context)
 
 
 @register.simple_tag
@@ -228,13 +227,13 @@ def next_url(target, calendar, period):
     if delta.total_seconds() > SCHEDULER_PREVNEXT_LIMIT_SECONDS:
         return ""
 
-    return mark_safe(
-        '<a href="%s%s"><span class="glyphicon glyphicon-circle-arrow-right"></span></a>'
-        % (
+    context = {
+        "url": "{}{}".format(
             reverse(target, kwargs={"calendar_slug": slug}),
             querystring_for_date(period.next().start),
         )
-    )
+    }
+    return get_template("schedule/_next.html").render(context)
 
 
 @register.inclusion_tag("schedule/_prevnext.html")


### PR DESCRIPTION
This PR allow the developer to override the prev/next tags, in my use case I need to use fontawesome but the a tag is hard-coded, so I can't override the a tag.

Please let me know if there is a better way to do this.

Someone else had a similar issue: https://github.com/llazzaro/django-scheduler/issues/519