### PR TITLE
fix(522): backports.zoneinfo.ZoneInfo object has no attribute localize

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,11 +21,11 @@ jobs:
           - django31
           - django32
           - django40
-        include:
-          - python-version: 3.8
-            tox-environment: djangomain
-          - python-version: 3.9
-            tox-environment: djangomain
+        # include:
+        #   - python-version: 3.8
+        #     tox-environment: djangomain
+        #   - python-version: 3.9
+        #     tox-environment: djangomain
         exclude:
           - python-version: 3.6
             tox-environment: django40

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,14 +18,19 @@ jobs:
           - 3.8
           - 3.9
         tox-environment:
-          - django22
           - django31
           - django32
+          - django40
         include:
           - python-version: 3.8
             tox-environment: djangomain
           - python-version: 3.9
             tox-environment: djangomain
+        exclude:
+          - python-version: 3.6
+            tox-environment: django40
+          - python-version: 3.7
+            tox-environment: django40
 
     env:
       TOXENV: ${{ matrix.tox-environment }}

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+0.9.6 -
+==========
+
+- Fix bug #522. 'backports.zoneinfo.ZoneInfo' object has no attribute 'localize' 
+
+
 0.9.5 - 2021-05-29
 ==========
 

--- a/schedule/periods.py
+++ b/schedule/periods.py
@@ -61,7 +61,7 @@ class Period:
         if point_in_time.tzinfo is not None:
             return point_in_time.astimezone(pytz.utc)
         if tzinfo is not None:
-            return tzinfo.localize(point_in_time).astimezone(pytz.utc)
+            return pytz.timezone(str(tzinfo)).localize(point_in_time)
         if settings.USE_TZ:
             return pytz.utc.localize(point_in_time)
         else:
@@ -228,8 +228,8 @@ class Year(Period):
         start = naive_start
         end = naive_end
         if self.tzinfo is not None:
-            local_start = self.tzinfo.localize(naive_start)
-            local_end = self.tzinfo.localize(naive_end)
+            local_start = pytz.timezone(str(self.tzinfo)).localize(naive_start)
+            local_end = pytz.timezone(str(self.tzinfo)).localize(naive_end)
             start = local_start.astimezone(pytz.utc)
             end = local_end.astimezone(pytz.utc)
 
@@ -319,8 +319,8 @@ class Month(Period):
         start = naive_start
         end = naive_end
         if self.tzinfo is not None:
-            local_start = self.tzinfo.localize(naive_start)
-            local_end = self.tzinfo.localize(naive_end)
+            local_start = pytz.timezone(str(self.tzinfo)).localize(naive_start)
+            local_end = pytz.timezone(str(self.tzinfo)).localize(naive_end)
             start = local_start.astimezone(pytz.utc)
             end = local_end.astimezone(pytz.utc)
 
@@ -402,8 +402,8 @@ class Week(Period):
         naive_end = naive_start + datetime.timedelta(days=7)
 
         if self.tzinfo is not None:
-            local_start = self.tzinfo.localize(naive_start)
-            local_end = self.tzinfo.localize(naive_end)
+            local_start = pytz.timezone(str(self.tzinfo)).localize(naive_start)
+            local_end = pytz.timezone(str(self.tzinfo)).localize(naive_end)
             start = local_start.astimezone(pytz.utc)
             end = local_end.astimezone(pytz.utc)
         else:
@@ -456,8 +456,8 @@ class Day(Period):
             date + datetime.timedelta(days=1), datetime.time.min
         )
         if self.tzinfo is not None:
-            local_start = self.tzinfo.localize(naive_start)
-            local_end = self.tzinfo.localize(naive_end)
+            local_start = pytz.timezone(str(self.tzinfo)).localize(naive_start)
+            local_end = pytz.timezone(str(self.tzinfo)).localize(naive_end)
             start = local_start.astimezone(pytz.utc)
             end = local_end.astimezone(pytz.utc)
         else:

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -23,6 +23,7 @@ class TestCalendarInheritance(TestCase):
 class TestCalendar(TestCase):
     def test_get_recent_events_without_events_is_empty(self):
         calendar = Calendar()
+        calendar.save()
         self.assertEqual(list(calendar.get_recent()), [])
 
     def test_get_recent_events_with_events_return_the_event(self):

--- a/tox.ini
+++ b/tox.ini
@@ -1,24 +1,24 @@
 [tox]
 envlist =
     lint
-    django22
     django31
     django32
-    djangomain
+    django40
+#    djangomain
 
 [testenv]
 commands = {envpython} -Wa -b -m coverage run -m django test --settings=tests.settings
 deps =
-    django22: Django>=2.2,<2.3
     django31: Django~=3.1.0
     django32: Django~=3.2.0
-    djangomain: https://github.com/django/django/archive/main.tar.gz
+    django40: Django~=4.0.0
+#    djangomain: https://github.com/django/django/archive/main.tar.gz
     coverage
 
 [testenv:lint]
 basepython = python3
 commands =
-    black --target-version py36 --check --diff .
+    black --target-version py39 --check --diff .
     flake8
     isort --check-only --diff .
     {envpython} -m django check --settings=tests.settings


### PR DESCRIPTION
Support for Django 4.0

Removed django22 since LTS is over.

