### PR TITLE
Save the calendar instance before testing occurences_after

### DIFF
--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -31,6 +31,7 @@ class TestCalendar(TestCase):
 
     def test_occurrences_after_without_events_is_empty(self):
         calendar = Calendar()
+        calendar.save()
         self.assertEqual(list(calendar.occurrences_after(timezone.now())), [])
 
     def test_occurrences_after_with_events_after_returns_events(self):


### PR DESCRIPTION
An unsaved instance can’t have related objects in the database
(occurrence_set).

Fixes failure in Django 4.1:
```
ERROR: test_occurrences_after_without_events_is_empty (tests.test_calendar.TestCalendar)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/runner/work/django-scheduler/django-scheduler/tests/test_calendar.py", line 34, in test_occurrences_after_without_events_is_empty
    self.assertEqual(list(calendar.occurrences_after(timezone.now())), [])
  File "/home/runner/work/django-scheduler/django-scheduler/schedule/models/calendars.py", line 176, in occurrences_after
    return EventListManager(self.events.all()).occurrences_after(date)
  File "/home/runner/work/django-scheduler/django-scheduler/schedule/models/calendars.py", line 154, in events
    return self.event_set
  File "/home/runner/work/django-scheduler/django-scheduler/.tox/django41/lib/python3.8/site-packages/django/db/models/fields/related_descriptors.py", line 596, in __get__
    instance_cache[key] = self.related_manager_cls(instance)
  File "/home/runner/work/django-scheduler/django-scheduler/.tox/django41/lib/python3.8/site-packages/django/db/models/fields/related_descriptors.py", line 634, in __init__
    raise ValueError(
ValueError: 'Calendar' instance needs to have a primary key value before this relationship can be used.