### PR TITLE
Replace requirements.txt with extras_require

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,0 @@
-coverage>=3.7.1
-Django>=1.11
-flake8
-icalendar>=3.8.4
-isort
-python-dateutil>=2.1
-pytz>=2013.9
-wheel

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,13 @@ setup(
         "pytz>=2013.9",
         "icalendar>=3.8.4",
     ],
+    extras_require={
+        "dev": [
+            "coverage>=3.7.1",
+            "flake8",
+            "isort",
+        ],
+    },
     license="BSD",
     test_suite="runtests.runtests",
 )


### PR DESCRIPTION
Avoid carrying an undocumented file with special meaning, which
partially duplicates setuptools options.

`wheel` is only needed for packaging, it was not added as part of the
development requirements.