### PR TITLE
Update setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -13,9 +13,9 @@ classifiers =
     Development Status :: 5 - Production/Stable
     Environment :: Web Environment
     Framework :: Django
-    Framework :: Django :: 2.2
-    Framework :: Django :: 3.1
     Framework :: Django :: 3.2
+    Framework :: Django :: 4.0
+    Framework :: Django :: 4.1
     Intended Audience :: Developers
     License :: OSI Approved :: BSD License
     Operating System :: OS Independent
@@ -25,14 +25,15 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Topic :: Utilities
 
 [options]
 include_package_data = True
 zip_safe = False
-python_requires = >=3.6
+python_requires = >=3.7
 install_requires=
-    Django>=2.2
+    Django>=3.2
     python-dateutil>=2.1
     pytz>=2013.9
     icalendar>=3.8.4
@@ -43,6 +44,12 @@ packages =
     schedule.migrations
     schedule.templatetags
 
+[options.extras_require]
+dev =
+    black
+    coverage>=3.7.1
+    flake8
+    isort
 
 [flake8]
 ignore =


### PR DESCRIPTION
The move from setup.py to setup.cfg
(https://github.com/llazzaro/django-scheduler/pull/533) caused some
obsolete metadata to be declared in setup.cfg.