### PR TITLE
Use setuptools automatic package discovery

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -36,12 +36,7 @@ install_requires=
     python-dateutil>=2.1
     pytz>=2013.9
     icalendar>=3.8.4
-packages =
-    schedule
-    schedule.feeds
-    schedule.models
-    schedule.migrations
-    schedule.templatetags
+packages = find:
 
 
 [flake8]


### PR DESCRIPTION
Avoids forgetting to add a package in the future.

`find:` includes tests in the packages, whereas the previous list
excluded tests.

This difference is intentional. Including test data in the package
allows end users to develop based on the distributed source, as well as
packagers (e.g. Linux distributions) to verify the project works as
intended on the machine.

Some references:

https://packaging.python.org/en/latest/flow/#the-source-distribution-sdist
https://wiki.debian.org/Python/LibraryStyleGuide#Style_Guide_for_Packaging_Python_Libraries
https://wiki.archlinux.org/title/Creating_packages#check()