### PR TITLE
views: _api_occurrences: Support handling of timezone-aware datetime …

### DIFF
--- a/schedule/views.py
+++ b/schedule/views.py
@@ -351,20 +351,11 @@ def _api_occurrences(start, end, calendar_slug, timezone):
     if not start or not end:
         raise ValueError("Start and end parameters are required")
     # version 2 of full calendar
-    # TODO: improve this code with date util package
     if "-" in start:
-
         def convert(ddatetime):
             if ddatetime:
-                ddatetime = ddatetime.split(" ")[0]
-                try:
-                    return datetime.datetime.strptime(ddatetime, "%Y-%m-%d")
-                except ValueError:
-                    # try a different date string format first before failing
-                    return datetime.datetime.strptime(ddatetime, "%Y-%m-%dT%H:%M:%S")
-
+                return dateutil.parser.parse(ddatetime)
     else:
-
         def convert(ddatetime):
             return datetime.datetime.utcfromtimestamp(float(ddatetime))
 
@@ -379,8 +370,8 @@ def _api_occurrences(start, end, calendar_slug, timezone):
     elif settings.USE_TZ:
         # If USE_TZ is True, make start and end dates aware in UTC timezone
         utc = pytz.UTC
-        start = utc.localize(start)
-        end = utc.localize(end)
+        start = utc.localize(start) if start.tzinfo is None else start
+        end = utc.localize(end) if end.tzinfo is None else end
 
     if calendar_slug:
         # will raise DoesNotExist exception if no match


### PR DESCRIPTION
…strings (2022-06-07T02:03:04+05:00).

Previously, such strings would fail with `ValueError` `unconverted data remains: +01:00`.

This patch changes it so it uses dateutil.parser.parse. The latter can parse all of the following and return a non-surprising result:

```
>>> dateutil.parser.parse('2020-01-01')
datetime.datetime(2020, 1, 1, 0, 0)
>>> dateutil.parser.parse('2020-01-01 05:42')
datetime.datetime(2020, 1, 1, 5, 42)
>>> dateutil.parser.parse('2020-01-01T05:42')
datetime.datetime(2020, 1, 1, 5, 42)
>>> dateutil.parser.parse('2020-01-01T05:42:00')
datetime.datetime(2020, 1, 1, 5, 42)
>>> dateutil.parser.parse('2020-01-01T05:42:00+01:00')
datetime.datetime(2020, 1, 1, 5, 42, tzinfo=tzoffset(None, 3600))
```

Additionally, since now it's possible for the `convert` function to return a datetime with `tzinfo` that is set, make sure not to try to add another (conflicting) tzinfo in that case.