### PR TITLE
Fix bug that results in AttributeError - 'OccurrencePreview' object has no attribute 'object'

### DIFF
--- a/schedule/migrations/0001_initial.py
+++ b/schedule/migrations/0001_initial.py
@@ -3,7 +3,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("contenttypes", "0001_initial"),
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),

--- a/schedule/migrations/0002_event_color_event.py
+++ b/schedule/migrations/0002_event_color_event.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("schedule", "0001_initial")]
 
     operations = [

--- a/schedule/migrations/0003_auto_20160715_0028.py
+++ b/schedule/migrations/0003_auto_20160715_0028.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("schedule", "0002_event_color_event")]
 
     operations = [

--- a/schedule/migrations/0004_text_fields_not_null.py
+++ b/schedule/migrations/0004_text_fields_not_null.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("schedule", "0003_auto_20160715_0028")]
 
     operations = [

--- a/schedule/migrations/0005_verbose_name_plural_for_calendar.py
+++ b/schedule/migrations/0005_verbose_name_plural_for_calendar.py
@@ -2,7 +2,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("schedule", "0004_text_fields_not_null")]
 
     operations = [

--- a/schedule/migrations/0006_update_text_fields_empty_string.py
+++ b/schedule/migrations/0006_update_text_fields_empty_string.py
@@ -30,7 +30,6 @@ def reverse(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("schedule", "0003_auto_20160715_0028")]
 
     operations = [migrations.RunPython(forwards, reverse, elidable=True)]

--- a/schedule/migrations/0007_merge_text_fields.py
+++ b/schedule/migrations/0007_merge_text_fields.py
@@ -2,7 +2,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("schedule", "0006_update_text_fields_empty_string"),
         ("schedule", "0005_verbose_name_plural_for_calendar"),

--- a/schedule/migrations/0008_gfk_index.py
+++ b/schedule/migrations/0008_gfk_index.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("contenttypes", "0002_remove_content_type_name"),
         ("schedule", "0007_merge_text_fields"),

--- a/schedule/migrations/0009_merge_20180108_2303.py
+++ b/schedule/migrations/0009_merge_20180108_2303.py
@@ -4,7 +4,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("schedule", "0008_gfk_index")]
 
     operations = []

--- a/schedule/migrations/0010_events_set_missing_calendar.py
+++ b/schedule/migrations/0010_events_set_missing_calendar.py
@@ -14,7 +14,6 @@ def forwards(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("schedule", "0009_merge_20180108_2303")]
 
     operations = [

--- a/schedule/migrations/0011_event_calendar_not_null.py
+++ b/schedule/migrations/0011_event_calendar_not_null.py
@@ -3,7 +3,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("schedule", "0010_events_set_missing_calendar")]
 
     operations = [

--- a/schedule/migrations/0012_auto_20191025_1852.py
+++ b/schedule/migrations/0012_auto_20191025_1852.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("schedule", "0011_event_calendar_not_null")]
 
     operations = [

--- a/schedule/migrations/0013_auto_20210502_2303.py
+++ b/schedule/migrations/0013_auto_20210502_2303.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("schedule", "0012_auto_20191025_1852"),
     ]

--- a/schedule/migrations/0014_use_autofields_for_pk.py
+++ b/schedule/migrations/0014_use_autofields_for_pk.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("schedule", "0013_auto_20210502_2303"),
     ]

--- a/schedule/periods.py
+++ b/schedule/periods.py
@@ -45,7 +45,6 @@ class Period:
         tzinfo=pytz.utc,
         sorting_options=None,
     ):
-
         self.utc_start = self._normalize_timezone_to_utc(start, tzinfo)
 
         self.utc_end = self._normalize_timezone_to_utc(end, tzinfo)
@@ -442,7 +441,6 @@ class Day(Period):
         )
 
     def _get_day_range(self, date):
-
         # localize the date before we typecast to naive dates
         if self.tzinfo is not None and timezone.is_aware(date):
             date = date.astimezone(self.tzinfo)

--- a/schedule/views.py
+++ b/schedule/views.py
@@ -166,7 +166,7 @@ class OccurrencePreview(OccurrenceMixin, ModelFormMixin, ProcessFormView):
             int(self.kwargs["hour"]),
             int(self.kwargs["minute"]),
             int(self.kwargs["second"]),
-            tzinfo=pytz.UTC
+            tzinfo=pytz.UTC,
         )
 
     def get_object(self, queryset=None):
@@ -376,7 +376,6 @@ def api_occurrences(request):
 
 
 def _api_occurrences(start, end, calendar_slug, timezone):
-
     if not start or not end:
         raise ValueError("Start and end parameters are required")
     # version 2 of full calendar

--- a/schedule/views.py
+++ b/schedule/views.py
@@ -34,7 +34,7 @@ from django.views.generic.edit import (
 
 from schedule.forms import EventForm, OccurrenceForm
 from schedule.models import Calendar, Event, Occurrence
-from schedule.periods import weekday_names, Period
+from schedule.periods import Period, weekday_names
 from schedule.settings import (
     CHECK_EVENT_PERM_FUNC,
     CHECK_OCCURRENCE_PERM_FUNC,

--- a/schedule/views.py
+++ b/schedule/views.py
@@ -34,7 +34,7 @@ from django.views.generic.edit import (
 
 from schedule.forms import EventForm, OccurrenceForm
 from schedule.models import Calendar, Event, Occurrence
-from schedule.periods import weekday_names
+from schedule.periods import weekday_names, Period
 from schedule.settings import (
     CHECK_EVENT_PERM_FUNC,
     CHECK_OCCURRENCE_PERM_FUNC,
@@ -156,6 +156,35 @@ class OccurrenceView(OccurrenceMixin, DetailView):
 
 class OccurrencePreview(OccurrenceMixin, ModelFormMixin, ProcessFormView):
     template_name = "schedule/occurrence.html"
+
+    @property
+    def date_from_url(self):
+        return datetime.datetime(
+            int(self.kwargs["year"]),
+            int(self.kwargs["month"]),
+            int(self.kwargs["day"]),
+            int(self.kwargs["hour"]),
+            int(self.kwargs["minute"]),
+            int(self.kwargs["second"]),
+            tzinfo=pytz.UTC
+        )
+
+    def get_object(self, queryset=None):
+        event = get_object_or_404(Event, pk=self.kwargs["event_id"])
+        period = Period(
+            [event],
+            start=self.date_from_url,
+            end=self.date_from_url,
+        )
+
+        try:
+            return period.get_occurrences()[0]
+        except IndexError:
+            raise Http404
+
+    def get(self, request, *args, **kwargs):
+        self.object = self.get_object()
+        return super().get(request, *args, **kwargs)
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data()

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -51,7 +51,6 @@ class TestEvent(TestCase):
         self.assertEqual(0, len(occurrences_one))
 
     def test_recurring_event_get_occurrences(self):
-
         cal = Calendar.objects.create(name="MyCal")
         rule = Rule.objects.create(frequency="WEEKLY")
 
@@ -76,7 +75,6 @@ class TestEvent(TestCase):
         )
 
     def test_event_get_occurrences_after(self):
-
         cal = Calendar.objects.create(name="MyCal")
         rule = Rule.objects.create(frequency="WEEKLY")
 
@@ -140,7 +138,6 @@ class TestEvent(TestCase):
         )
 
     def test_recurring_event_get_occurrences_after(self):
-
         cal = Calendar.objects.create(name="MyCal")
         rule = Rule.objects.create(frequency="WEEKLY")
         recurring_event = self.__create_recurring_event(
@@ -188,7 +185,6 @@ class TestEvent(TestCase):
         self.assertEqual(occurrence, occurrence2)
 
     def test_recurring_event_get_occurrence(self):
-
         cal = Calendar.objects.create(name="MyCal")
         rule = Rule.objects.create(frequency="WEEKLY")
 
@@ -442,7 +438,6 @@ class TestEvent(TestCase):
         self.assertEqual(occurrences[-1].end, end_recurring)
 
     def test_recurring_event_get_occurrence_across_dst(self):
-
         pacific = pytz.timezone("US/Pacific")
         e_start = pacific.localize(datetime.datetime(2015, 3, 4, 9, 0))
         e_end = e_start

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -689,7 +689,7 @@ class TestOccurrencePreview(TestCase):
                 "hour": 8,
                 "minute": 30,
                 "second": 0,
-            }
+            },
         )
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -663,3 +663,44 @@ class TestUrls(TestCase):
         self.assertTrue(
             '<a href="/feed/calendar/upcoming/1/">Feed</a>' in response.content.decode()
         )
+
+
+class TestOccurrencePreview(TestCase):
+    def setUp(self):
+        self.rule = Rule.objects.create(frequency="DAILY")
+        self.calendar = Calendar.objects.create(name="MyCal", slug="MyCalSlug")
+        self.event = Event.objects.create(
+            title="Recent Event",
+            start=datetime.datetime(2008, 1, 5, 8, 0, tzinfo=pytz.utc),
+            end=datetime.datetime(2008, 1, 5, 9, 0, tzinfo=pytz.utc),
+            end_recurring_period=datetime.datetime(2008, 5, 5, 0, 0, tzinfo=pytz.utc),
+            rule=self.rule,
+            calendar=self.calendar,
+        )
+
+    def test_generates_preview(self):
+        url = reverse(
+            "occurrence_by_date",
+            kwargs={
+                "event_id": self.event.pk,
+                "year": 2008,
+                "month": 4,
+                "day": 20,
+                "hour": 8,
+                "minute": 30,
+                "second": 0,
+            }
+        )
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "schedule/occurrence.html")
+        self.assertEqual(response.context["event"], self.event)
+
+        occurrence = response.context["occurrence"]
+        self.assertEqual(occurrence.event, self.event)
+        self.assertEqual(
+            occurrence.start, datetime.datetime(2008, 4, 20, 8, 0, tzinfo=pytz.utc)
+        )
+        self.assertEqual(
+            occurrence.end, datetime.datetime(2008, 4, 20, 9, 0, tzinfo=pytz.utc)
+        )


### PR DESCRIPTION
Fixes issues #301 and #554 

A couple of issues identified with the `OccurrencePreview` view - as follows:

- The MRO of the `OccurrencePreview` class means that the `ProcessFormView.get` method is called first and foremost. `ProcessFormView.get` does not invoke the `get_object` method meaning the object is never fetched from the database.
- The `model` attribute defined on the view class is `Occurrence`. The `pk_url_kwarg` attribute on the view class is `occurrence_id`.  The url pattern that this view class is bound to does not define an `occurrence_id` pattern meaning the `get_object` method call would fail if the default implementation of `get_object` were used

As a result of the above, when `get_context_data` is called, the `object` attribute of the view has not been set, resulting in an `AttributeError`.

The fix involves:

1. using the `event_id` from the url pattern to fetch the event from the db
2. getting the associated occurrence by constructing the start/end dates from the url parameters and using the `Period` class to get occurrences for that point in time
3. returning the occurrence if found
4. raising an http 404 if the event could not be found, or no occurrences exist for the specified point in time

Thanks for the library.  Please let me know if you'd like anything changed in the pull request