### PR TITLE
Django 5.1 Support - deprecated index_together

### DIFF
--- a/schedule/models/calendars.py
+++ b/schedule/models/calendars.py
@@ -231,7 +231,7 @@ class CalendarRelation(models.Model):
     class Meta:
         verbose_name = _("calendar relation")
         verbose_name_plural = _("calendar relations")
-        index_together = [("content_type", "object_id")]
+        indexes = [models.Index(fields=["content_type", "object_id"])]
 
     def __str__(self):
         return "{} - {}".format(self.calendar, self.content_object)

--- a/schedule/models/events.py
+++ b/schedule/models/events.py
@@ -92,7 +92,7 @@ class Event(models.Model):
     class Meta:
         verbose_name = _("event")
         verbose_name_plural = _("events")
-        index_together = (("start", "end"),)
+        indexes = [models.Index(fields=["start", "end"])]
 
     def __str__(self):
         return gettext("%(title)s: %(start)s - %(end)s") % {
@@ -571,7 +571,7 @@ class EventRelation(models.Model):
     class Meta:
         verbose_name = _("event relation")
         verbose_name_plural = _("event relations")
-        index_together = [("content_type", "object_id")]
+        indexes = [models.Index(fields=["content_type", "object_id"])]
 
     def __str__(self):
         return "{}({})-{}".format(
@@ -594,7 +594,7 @@ class Occurrence(models.Model):
     class Meta:
         verbose_name = _("occurrence")
         verbose_name_plural = _("occurrences")
-        index_together = (("start", "end"),)
+        indexes = [models.Index(fields=["start", "end"])]
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)


### PR DESCRIPTION
Fix pulled from Django 4.2 release notes here - 

https://docs.djangoproject.com/en/5.1/releases/4.2/#deprecated-features-4-2

Migrating existing index_together should be handled as a migration. For example:

```
class Author(models.Model):
    rank = models.IntegerField()
    name = models.CharField(max_length=30)

    class Meta:
        index_together = [["rank", "name"]]
```

Should become:

```
class Author(models.Model):
    rank = models.IntegerField()
    name = models.CharField(max_length=30)

    class Meta:
        indexes = [models.Index(fields=["rank", "name"])]
```