### PR TITLE
Remove duplicate CALENDAR_VIEW_PERM setting

### DIFF
--- a/schedule/settings.py
+++ b/schedule/settings.py
@@ -39,8 +39,6 @@ if not CHECK_CALENDAR_PERM_FUNC:
 
     CHECK_CALENDAR_PERM_FUNC = check_calendar_permission
 
-CALENDAR_VIEW_PERM = getattr(settings, "CALENDAR_VIEW_PERM", False)
-
 # Callable used to customize the event list given for a calendar and user
 # (e.g. all events on that calendar, those events plus another calendar's events,
 # or the events filtered based on user permissions)


### PR DESCRIPTION
CALENDAR_VIEW_PERM was defined twice in settings.py. Remove the second definition.