### PR TITLE
Fix CalendarNode.render to not discard query result

### DIFF
--- a/schedule/templatetags/scheduletags.py
+++ b/schedule/templatetags/scheduletags.py
@@ -112,9 +112,6 @@ class CalendarNode(template.Node):
         self.context_var = context_var
 
     def render(self, context):
-        Calendar.objects.get_calendar_for_object(
-            self.content_object.resolve(context), self.distinction
-        )
         context[self.context_var] = Calendar.objects.get_calendar_for_object(
             self.content_object.resolve(context), self.distinction
         )


### PR DESCRIPTION
CalendarNode.render called get_calendar_for_object twice: once discarding the result, then again to assign it to the context variable. Remove the redundant first call.